### PR TITLE
Disable upx compress for mips64

### DIFF
--- a/brook/Makefile
+++ b/brook/Makefile
@@ -55,6 +55,7 @@ define Package/brook/config
 
 	config BROOK_COMPRESS_UPX
 		bool "Compress executable files with UPX"
+		depends on @!mips64
 		default y
 endef
 

--- a/hysteria/Makefile
+++ b/hysteria/Makefile
@@ -50,6 +50,7 @@ config HYSTERIA_COMPRESS_GOPROXY
 
 config HYSTERIA_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 
 endmenu

--- a/trojan-go/Makefile
+++ b/trojan-go/Makefile
@@ -53,6 +53,7 @@ config TROJAN_GO_COMPRESS_GOPROXY
 
 config TROJAN_GO_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 
 endmenu

--- a/v2ray-core/Makefile
+++ b/v2ray-core/Makefile
@@ -104,6 +104,7 @@ config V2RAY_CORE_COMPRESS_GOPROXY
 
 config V2RAY_CORE_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endmenu
 endef
@@ -118,6 +119,7 @@ config V2RAY_CTL_COMPRESS_GOPROXY
 
 config V2RAY_CTL_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endmenu
 endef

--- a/v2ray-plugin/Makefile
+++ b/v2ray-plugin/Makefile
@@ -28,7 +28,9 @@ GO_PKG:=github.com/shadowsocks/v2ray-plugin
 GO_PKG_LDFLAGS:=-s -w
 GO_PKG_LDFLAGS_X:=main.VERSION=v$(PKG_VERSION)
 
-PKG_CONFIG_DEPENDS := CONFIG_$(PKG_NAME)_INCLUDE_GOPROXY
+PKG_CONFIG_DEPENDS := \
+	CONFIG_$(PKG_NAME)_INCLUDE_GOPROXY \
+	CONFIG_$(PKG_NAME)_COMPRESS_UPX
 
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
@@ -38,6 +40,11 @@ config $(PKG_NAME)_INCLUDE_GOPROXY
 	bool "Compiling with GOPROXY proxy"
 	default n
 
+config $(PKG_NAME)_COMPRESS_UPX
+	bool "Compress executable files with UPX"
+	depends on @!mips64
+	default y
+endef
 endef
 
 ifeq ($(CONFIG_$(PKG_NAME)_INCLUDE_GOPROXY),y)
@@ -60,7 +67,9 @@ endef
 
 define Build/Compile
 	$(call GoPackage/Build/Compile)
+ifneq ($(CONFIG_$(PKG_NAME)_COMPRESS_UPX),)
 	$(STAGING_DIR_HOST)/bin/upx --lzma --best $(GO_PKG_BUILD_BIN_DIR)/v2ray-plugin
+endif
 endef
 
 define Package/$(PKG_NAME)/install

--- a/xray-core/Makefile
+++ b/xray-core/Makefile
@@ -94,6 +94,7 @@ config XRAY_CORE_COMPRESS_GOPROXY
 
 config XRAY_CORE_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endmenu
 endef

--- a/xray-plugin/Makefile
+++ b/xray-plugin/Makefile
@@ -46,6 +46,7 @@ config XRAY_PLUGIN_COMPRESS_GOPROXY
 
 config XRAY_PLUGIN_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endef
 


### PR DESCRIPTION
Unsupported and cause build errors. https://github.com/upx/upx/issues/272