### PR TITLE
luci: add chinadns-ng allow no-ip reply from chinadns config

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -391,6 +391,10 @@ o.description = "<ul>"
 		.. "</ul>"
 o:depends({dns_shunt = "chinadns-ng", tcp_proxy_mode = "proxy", chn_list = "direct"})
 
+o = s:taboption("DNS", Flag, "chinadns_ng_allow_noip", "ChinaDNS-NG " .. translate("allow no-ip reply from chinadns"), translate("Enable to improve DNS resolution speed for some China IPv4 Only domain names."))
+o.default = "0"
+o:depends({dns_shunt = "chinadns-ng", tcp_proxy_mode = "proxy", chn_list = "direct"})
+
 o = s:taboption("DNS", ListValue, "use_default_dns", translate("Default DNS"))
 o.default = "direct"
 o:value("remote", translate("Remote DNS"))

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -178,6 +178,12 @@ msgstr "ChinaDNS-NG 域名默认标签"
 msgid "Default: Forward to both direct and remote DNS, if the direct DNS resolution result is a mainland China ip, then use the direct result, otherwise use the remote result."
 msgstr "默认：同时转发给直连和远程DNS，如果直连DNS解析结果是大陆ip，则使用直连结果，否则使用远程结果。"
 
+msgid "allow no-ip reply from chinadns"
+msgstr "接受中国 DNS 空响应"
+
+msgid "Enable to improve DNS resolution speed for some China IPv4 Only domain names."
+msgstr "开启后可提升部分 China IPv4 Only 域名的 DNS 解析速度。"
+
 msgid "Filter Proxy Host IPv6"
 msgstr "过滤代理域名 IPv6"
 

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -588,6 +588,9 @@ run_chinadns_ng() {
 	([ -z "${_default_tag}" ] || [ "${_default_tag}" = "smart" ]) && _default_tag="none"
 	echo "default-tag ${_default_tag}" >> ${_CONF_FILE}
 
+	local _chinadns_ng_allow_noip=$(config_t_get global chinadns_ng_allow_noip "0")
+	[ "${_chinadns_ng_allow_noip}" = "1" ] && echo "noip-as-chnip" >> ${_CONF_FILE}
+
 	ln_run "$(first_type chinadns-ng)" chinadns-ng "${_LOG_FILE}" -C ${_CONF_FILE}
 }
 


### PR DESCRIPTION
使用 cURL 请求未收录在 gfw/chn 列表中的域名时，如果解析结果为 China IPv4 Only（即中国 IP，只有 A 记录，AAAA 记录为空），还需要等待远程 DNS 响应 AAAA 结果，节点异常时还会导致 cURL 请求异常，增加此选项来缓解问题，默认关闭。