### PR TITLE
luci: optimize

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/helper_chinadns_add.lua
+++ b/luci-app-passwall/root/usr/share/passwall/helper_chinadns_add.lua
@@ -482,7 +482,7 @@ table.insert(config_lines, "default-tag " .. DEFAULT_TAG)
 table.insert(config_lines, "cache 4096")
 table.insert(config_lines, "cache-stale 3600")
 
-if DEFAULT_TAG == "none" then
+if DEFAULT_TAG == "none" or DEFAULT_TAG == "none_noip" then
 	table.insert(config_lines, "verdict-cache 5000")
 end
 


### PR DESCRIPTION
Modify to allow the “none_noip” mode to also support “verdict-cache” caching to reduce duplicate requests and DNS leakage, as this mode is basically the same as the “none” mode, the difference only lies in whether or not it accepts direct DNS null resolution.