### PR TITLE
luci: optimize

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -1067,7 +1067,6 @@ add_firewall_rule() {
 	unset WAN6_IP
 
 	insert_rule_before "$ip6t_m" "PREROUTING" "mwan3" "-j PSW"
-	insert_rule_before "$ip6t_m" "PREROUTING" "PSW" "-p tcp -m socket -j PSW_DIVERT"
 
 	$ip6t_m -N PSW_OUTPUT
 	$ip6t_m -A PSW_OUTPUT -m mark --mark 0xff -j RETURN

--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -1416,7 +1416,7 @@ gen_include() {
 			PR_INDEX=\$(sh ${MY_PATH} RULE_LAST_INDEX "$NFTABLE_NAME" PSW_MANGLE_V6 WAN6_IP_RETURN -1)
 			if [ \$PR_INDEX -ge 0 ]; then
 				WAN6_IP=\$(sh ${MY_PATH} get_wan6_ip)
-				[ ! -z "\${WAN_IP}" ] && nft "replace rule $NFTABLE_NAME PSW_MANGLE_V6 handle \$PR_INDEX ip6 daddr "\${WAN6_IP}" counter return comment \"WAN6_IP_RETURN\""
+				[ ! -z "\${WAN6_IP}" ] && nft "replace rule $NFTABLE_NAME PSW_MANGLE_V6 handle \$PR_INDEX ip6 daddr "\${WAN6_IP}" counter return comment \"WAN6_IP_RETURN\""
 			fi
 		}
 	EOF


### PR DESCRIPTION
晚上用 AI 配合读了下防火墙代码，尝试着改一下可能存在问题的地方。

以下这些不确定所以没动，因为 AI 不完全可靠，等大佬们看一下：
1. nftables.sh 中有一些代码写成了 `nft "add $NFTABLE_NAME ......`，AI 认为语法错误，应该使用正确的语法 `add rule <table> <chain> ...`
2. nftables.sh 中 L1282 可能错误将 udp 写成了 tcp，与 TCP 及 iptables 相关代码对比后发现 L1273、L1282 可能缺少端口参数：
https://github.com/xiaorouji/openwrt-passwall/blob/d1adb2a3e2a9f5b09dfe6eb5794196b6b107d1d9/luci-app-passwall/root/usr/share/passwall/nftables.sh#L1264-L1285