### PR TITLE
add rr_ttl_reply_max configuration to helper_smartdns

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/helper_smartdns_add.lua
+++ b/luci-app-passwall/root/usr/share/passwall/helper_smartdns_add.lua
@@ -121,7 +121,8 @@ else
 		{key = "response_mode", config_key = "response-mode", prefix = "-r ", default = "first-ping"},
 		{key = "rr_ttl", config_key = "rr-ttl", prefix = "-rr-ttl "},
 		{key = "rr_ttl_min", config_key = "rr-ttl-min", prefix = "-rr-ttl-min "},
-		{key = "rr_ttl_max", config_key = "rr-ttl-max", prefix = "-rr-ttl-max "}
+		{key = "rr_ttl_max", config_key = "rr-ttl-max", prefix = "-rr-ttl-max "},
+		{key = "rr_ttl_reply_max", config_key = "rr-ttl-reply-max", prefix = "-rr-ttl-reply-max "}
 	}
 	-- 从 custom.conf 中读取值，以最后出现的值为准
 	local custom_config = {}


### PR DESCRIPTION
Implement the integration of the `rr-ttl-reply-max` parameter into the SmartDNS configuration interface within the helper/passwall rules.

This enhancement addresses the requirement for decoupled Time-To-Live (TTL) management between the SmartDNS upstream cache and the downstream client response.

The core motivation is to:
* **Optimize Backend Caching:** Allow SmartDNS to utilize long TTLs for internal caching, thereby maximizing cache hit ratios and reducing overall load on upstream resolvers.
* **Improve Client Responsiveness:** Enforce a lower, user-defined maximum TTL on responses served to clients.

This dual-layer approach significantly improves client-side record update speed, which is critical for mitigating stale DNS entries and ensuring rapid resolution changes, particularly after network topology shifts (e.g., VPN tunnel renegotiation or switchover).