### PR TITLE
luci: fix clearing luci cache.

### DIFF
--- a/luci-app-passwall/root/etc/uci-defaults/luci-passwall
+++ b/luci-app-passwall/root/etc/uci-defaults/luci-passwall
@@ -42,7 +42,7 @@ uci -q commit passwall
 
 sed -i "s#add_from#group#g" /etc/config/passwall 2>/dev/null
 
-rm -f /tmp/luci-indexcache
+rm -f /tmp/luci-indexcache /tmp/luci-indexcache.*
 rm -rf /tmp/luci-modulecache/
 killall -HUP rpcd 2>/dev/null
 


### PR DESCRIPTION
The path to the LuCI index cache file has changed to /tmp/luci-indexcache.*.json since OpenWrt 22.03.