### PR TITLE
nonIPQuery 从 drop 改为 reject 以解决 iOS 查询非 AAA/A 时过长的无效等待时间

### DIFF
--- a/luci-app-passwall/luasrc/passwall/util_xray.lua
+++ b/luci-app-passwall/luasrc/passwall/util_xray.lua
@@ -1398,7 +1398,7 @@ function gen_config(var)
 					address = remote_dns_udp_server or remote_dns_tcp_server,
 					port = tonumber(remote_dns_udp_port) or tonumber(remote_dns_tcp_port),
 					network = remote_dns_udp_server and "udp" or "tcp",
-					nonIPQuery = "drop"
+					nonIPQuery = "reject"
 				}
 			})
 


### PR DESCRIPTION
本人手机是 iPhone 以前都是自己本地修改这个设置 但每次更新都得重新改 于是来 PR 看看