### PR TITLE
luci: force regenerated rule from geofile

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
@@ -72,10 +72,11 @@ if has_xray or has_singbox then
 	o.rmempty = false
 
 	if api.is_finded("geoview") then
-		o = s:option(Flag, "geo2rule", translate("Generate Rule List from Geo"), translate("Generate rule lists such as GFW, China domains, and China IP ranges based on Geo files."))
+		o = s:option(Flag, "geo2rule", translate("Generate Rule List from Geo"))
 		o.default = 0
 		o.rmempty = false
-		o.description = "<font color='red'>" .. translate("When manually updating with this option enabled, rules will be regenerated from existing Geo files even if no new version is available.") .. "</font>"
+		o.description = translate("Generate rule lists such as GFW, China domains, and China IP ranges based on Geo files.") .. "<br><font color='red'>" ..
+			translate("When manually updating with this option enabled, rules will be regenerated from existing Geo files even if no new version is available.") .. "</font>"
 
 		o = s:option(Flag, "enable_geoview", translate("Enable Geo Data Parsing"))
 		o.default = 0

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
@@ -75,6 +75,7 @@ if has_xray or has_singbox then
 		o = s:option(Flag, "geo2rule", translate("Generate Rule List from Geo"), translate("Generate rule lists such as GFW, China domains, and China IP ranges based on Geo files."))
 		o.default = 0
 		o.rmempty = false
+		o.description = "<font color='red'>" .. translate("When manually updating with this option enabled, rules will be regenerated from existing Geo files even if no new version is available.") .. "</font>"
 
 		o = s:option(Flag, "enable_geoview", translate("Enable Geo Data Parsing"))
 		o.default = 0

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -1009,6 +1009,9 @@ msgstr "从 Geo 文件生成规则"
 msgid "Generate rule lists such as GFW, China domains, and China IP ranges based on Geo files."
 msgstr "根据 Geo 文件生成规则列表，包括 GFW、中国域名和中国 IP 段等。"
 
+msgid "When manually updating with this option enabled, rules will be regenerated from existing Geo files even if no new version is available."
+msgstr "启用此选项后手动更新时,即使没有新版本也会从现有 Geo 文件重新生成规则。"
+
 msgid "Enable Geo Data Parsing"
 msgstr "开启 Geo 数据解析"
 

--- a/luci-app-passwall/root/usr/share/passwall/rule_update.lua
+++ b/luci-app-passwall/root/usr/share/passwall/rule_update.lua
@@ -678,41 +678,38 @@ local function remove_tmp_geofile(name)
 end
 
 if geo2rule == "1" then
-    if geoip_update == "1" then
-        log("geoip 开始更新...")
-        safe_call(fetch_geoip, "更新geoip发生错误...")
-        remove_tmp_geofile("geoip")
-    end
+	if geoip_update == "1" then
+		log("geoip 开始更新...")
+		safe_call(fetch_geoip, "更新geoip发生错误...")
+		remove_tmp_geofile("geoip")
+	end
 
-    if geosite_update == "1" then
-        log("geosite 开始更新...")
-        safe_call(fetch_geosite, "更新geosite发生错误...")
-        remove_tmp_geofile("geosite")
-    end
+	if geosite_update == "1" then
+		log("geosite 开始更新...")
+		safe_call(fetch_geosite, "更新geosite发生错误...")
+		remove_tmp_geofile("geosite")
+	end
 
-    -- 修改判断逻辑:检查文件是否存在,而不是是否有更新
-    -- 如果是手动更新(arg2存在)且文件存在,强制执行规则生成
-    local force_generate = (arg2 ~= nil)
-    
-    if geoip_update == "1" then
-        local geoip_exists = fs.access(asset_location .. "geoip.dat")
-        if not geoip_exists then
-            log("geoip.dat 文件不存在,跳过规则生成。")
-        elseif geoip_update_ok or force_generate then
-            safe_call(fetch_chnroute, "生成chnroute发生错误...")
-            safe_call(fetch_chnroute6, "生成chnroute6发生错误...")
-        end
-    end
+	-- 如果是手动更新(arg2存在)始终生成规则
+	local force_generate = (arg2 ~= nil)
 
-    if geosite_update == "1" then
-        local geosite_exists = fs.access(asset_location .. "geosite.dat")
-        if not geosite_exists then
-            log("geosite.dat 文件不存在,跳过规则生成。")
-        elseif geosite_update_ok or force_generate then
-            safe_call(fetch_gfwlist, "生成gfwlist发生错误...")
-            safe_call(fetch_chnlist, "生成chnlist发生错误...")
-        end
-    end
+	if geoip_update_ok or force_generate then
+		if fs.access(asset_location .. "geoip.dat") then
+			safe_call(fetch_chnroute, "生成chnroute发生错误...")
+			safe_call(fetch_chnroute6, "生成chnroute6发生错误...")
+		else
+			log("geoip.dat 文件不存在,跳过规则生成。")
+		end
+	end
+
+	if geosite_update_ok or force_generate then
+		if fs.access(asset_location .. "geosite.dat") then
+			safe_call(fetch_gfwlist, "生成gfwlist发生错误...")
+			safe_call(fetch_chnlist, "生成chnlist发生错误...")
+		else
+			log("geosite.dat 文件不存在,跳过规则生成。")
+		end
+	end
 else
 	if gfwlist_update == "1" then
 		safe_call(fetch_gfwlist, "更新gfwlist发生错误...")

--- a/luci-app-passwall/root/usr/share/passwall/rule_update.lua
+++ b/luci-app-passwall/root/usr/share/passwall/rule_update.lua
@@ -678,27 +678,41 @@ local function remove_tmp_geofile(name)
 end
 
 if geo2rule == "1" then
-	if geoip_update == "1" then
-		log("geoip 开始更新...")
-		safe_call(fetch_geoip, "更新geoip发生错误...")
-		remove_tmp_geofile("geoip")
-	end
+    if geoip_update == "1" then
+        log("geoip 开始更新...")
+        safe_call(fetch_geoip, "更新geoip发生错误...")
+        remove_tmp_geofile("geoip")
+    end
 
-	if geosite_update == "1" then
-		log("geosite 开始更新...")
-		safe_call(fetch_geosite, "更新geosite发生错误...")
-		remove_tmp_geofile("geosite")
-	end
+    if geosite_update == "1" then
+        log("geosite 开始更新...")
+        safe_call(fetch_geosite, "更新geosite发生错误...")
+        remove_tmp_geofile("geosite")
+    end
 
-	if geoip_update_ok then
-		safe_call(fetch_chnroute, "生成chnroute发生错误...")
-		safe_call(fetch_chnroute6, "生成chnroute6发生错误...")
-	end
+    -- 修改判断逻辑:检查文件是否存在,而不是是否有更新
+    -- 如果是手动更新(arg2存在)且文件存在,强制执行规则生成
+    local force_generate = (arg2 ~= nil)
+    
+    if geoip_update == "1" then
+        local geoip_exists = fs.access(asset_location .. "geoip.dat")
+        if not geoip_exists then
+            log("geoip.dat 文件不存在,跳过规则生成。")
+        elseif geoip_update_ok or force_generate then
+            safe_call(fetch_chnroute, "生成chnroute发生错误...")
+            safe_call(fetch_chnroute6, "生成chnroute6发生错误...")
+        end
+    end
 
-	if geosite_update_ok then
-		safe_call(fetch_gfwlist, "生成gfwlist发生错误...")
-		safe_call(fetch_chnlist, "生成chnlist发生错误...")
-	end
+    if geosite_update == "1" then
+        local geosite_exists = fs.access(asset_location .. "geosite.dat")
+        if not geosite_exists then
+            log("geosite.dat 文件不存在,跳过规则生成。")
+        elseif geosite_update_ok or force_generate then
+            safe_call(fetch_gfwlist, "生成gfwlist发生错误...")
+            safe_call(fetch_chnlist, "生成chnlist发生错误...")
+        end
+    end
 else
 	if gfwlist_update == "1" then
 		safe_call(fetch_gfwlist, "更新gfwlist发生错误...")


### PR DESCRIPTION
有些时候，op刷系统了，geofile又是最新版本，相关rule又是根据geofile生成的情况，当用户手动更新，系统检测没有新的geofile可更新的情况，可能会导致rule规则落后。

修改一些逻辑，当用户勾选从 Geo 文件生成规则时，无论是否有新的geofile，都执行更新逻辑。