### PR TITLE
fix: allow _iface nodes to appear in Main tab dropdown when no normal…

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -144,7 +144,7 @@ end
 
 -- Shunt Start
 if (has_singbox or has_xray) and #nodes_table > 0 then
-	if #normal_list > 0 then
+	if #normal_list > 0 or #iface_list > 0 then
 		current_node_id = m.uci:get(appname, global_cfgid, "tcp_node")
 		current_node = current_node_id and m.uci:get_all(appname, current_node_id) or {}
 		if current_node.protocol == "_shunt" then
@@ -163,7 +163,7 @@ if (has_singbox or has_xray) and #nodes_table > 0 then
 			})
 		end
 	else
-		local tips = s:taboption("Main", DummyValue, "tips", " ")
+		local tips = s:taboption("Main", DummyValue, "tips", "　")
 		tips.rawhtml = true
 		tips.cfgvalue = function(t, n)
 			return string.format('<a style="color: red">%s</a>', translate("There are no available nodes, please add or subscribe nodes first."))
@@ -796,7 +796,7 @@ for k, v in pairs(socks_list) do
 	udp.group[#udp.group+1] = (v.group and v.group ~= "") and v.group or translate("default")
 end
 for k, v in pairs(nodes_table) do
-	if #normal_list == 0 and v.protocol ~= "_iface" then
+	if #normal_list == 0 and #iface_list == 0 then
 		break
 	end
 	if v.protocol == "_shunt" then

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -796,7 +796,7 @@ for k, v in pairs(socks_list) do
 	udp.group[#udp.group+1] = (v.group and v.group ~= "") and v.group or translate("default")
 end
 for k, v in pairs(nodes_table) do
-	if #normal_list == 0 then
+	if #normal_list == 0 and v.protocol ~= "_iface" then
 		break
 	end
 	if v.protocol == "_shunt" then


### PR DESCRIPTION
当节点列表中没有普通代理节点（带服务器地址的节点），仅有自定义接口（`_iface`）节点时，在"主要"选项卡的 TCP/UDP 节点下拉菜单中无法看到和选中该节点。

只能通过在"节点列表"中点击"使用"按钮来启用，但返回"主要"选项卡后显示"Not set"，无法保存。

复现步骤
1. 创建一个 Xray/_iface 类型节点（自定义接口）
2. 不创建任何普通代理节点
3. 进入 主要 选项卡 → 下拉菜单中看不到该节点
4. 从节点列表点"使用" → 生效但主要选项卡显示 "Not set"