### PR TITLE
luci: Fix the issue where Xray's ech cannot be encrypted and make it compatible with the latest version.

### DIFF
--- a/luci-app-passwall/luasrc/passwall/util_xray.lua
+++ b/luci-app-passwall/luasrc/passwall/util_xray.lua
@@ -171,8 +171,10 @@ function gen_outbound(flag, node, tag, proxy_table)
 								if not node.tls_CertByName then return "" end
 								return node.tls_CertByName
 							end)(),
-					echConfigList = (node.ech == "1") and node.ech_config or nil,
-					echForceQuery = (node.ech == "1") and (node.ech_ForceQuery or "none") or nil
+					echSettings = (node.ech == '1') and {
+						ConfigList = node.ech_config,
+						ForceQuery = node.ech_ForceQuery or "none"
+					} or nil,
 				} or nil,
 				realitySettings = (node.stream_security == "reality") and {
 					serverName = node.tls_serverName,


### PR DESCRIPTION
最新版本无法兼容目前的配置，表现在能运行但不能代理。同时，ech即使在26.2.6版本能代理情况下却并未生效。
**26.2.6：**
<img width="1180" height="261" alt="image" src="https://github.com/user-attachments/assets/4d86f397-8b89-46fa-9bc0-c1feebfc99f6" />
**26.3.23和26.2.6：**
<img width="1217" height="419" alt="image" src="https://github.com/user-attachments/assets/64761f58-fe90-4124-a6c6-ed02886d2506" />
