### PR TITLE
fix: 修复链式代理下非Xray落地节点的inbound tag冲突及协议空指针问题

### DIFF
--- a/luci-app-passwall/luasrc/passwall/util_xray.lua
+++ b/luci-app-passwall/luasrc/passwall/util_xray.lua
@@ -1064,17 +1064,17 @@ function gen_config(var)
 				local to_node = get_node_by_id(node.to_node)
 				if to_node then
 					-- Landing Node not support use special node.
-					if to_node.protocol:find("^_") then
+					if to_node.protocol and to_node.protocol:find("^_") then
 						to_node = nil
 					end
 				end
 				if to_node then
 					local to_outbound
 					if to_node.type ~= "Xray" then
-						local tag = to_node[".name"]
+						local in_tag = "inbound_" .. to_node[".name"] .. "_" .. tostring(outbound.tag)
 						local new_port = api.get_new_port()
 						table.insert(inbounds, {
-							tag = tag,
+							tag = in_tag,
 							listen = "127.0.0.1",
 							port = new_port,
 							protocol = "dokodemo-door",
@@ -1086,11 +1086,11 @@ function gen_config(var)
 						to_node.address = "127.0.0.1"
 						to_node.port = new_port
 						table.insert(rules, 1, {
-							inboundTag = {tag},
+							inboundTag = {in_tag},
 							outboundTag = outbound.tag
 						})
-						to_outbound = gen_outbound(node[".name"], to_node, tag, {
-							tag = tag,
+						to_outbound = gen_outbound(node[".name"], to_node, to_node[".name"], {
+							tag = to_node[".name"],
 							run_socks_instance = not no_run
 						})
 					else


### PR DESCRIPTION
### 修复说明

1. 补充了对 `to_node.protocol` 的判空逻辑保护。
2. 修复了当降级使用 dokodemo-door inbound 时，原本过于简单的 `tag = to_node['.name']` 容易在多个节点引用同名落地节点或重名情况下引发的出栈冲突，现在修改成了更加严谨唯一的拼接 `inbound_{tag}_{outbound.tag}` 形式。

此修复消除了部分链式分流（如SS-Rust前置代理）配置下导致的组件报错。