### PR TITLE
fix: prevent local loopback for both nftables and iptables across IPv4/IPv6

### DIFF
--- a/0001-fix-prevent-local-loopback-for-both-nftables-and-ipt.patch
+++ b/0001-fix-prevent-local-loopback-for-both-nftables-and-ipt.patch
@@ -1,0 +1,175 @@
+From 5c8c091ef24d97973a4a170382c78d0b5411950d Mon Sep 17 00:00:00 2001
+From: AI Bot <bot@example.com>
+Date: Fri, 10 Apr 2026 09:30:36 +0000
+Subject: [PATCH] fix: prevent local loopback for both nftables and iptables
+ across IPv4/IPv6
+
+- Added mandatory bypass rules for local and LAN IP sets in all mangle and output chains to prevent traffic from looping between the firewall and the proxy.
+- Covered both IPv4 and IPv6 protocols.
+- Ensured consistency across modern nftables and legacy iptables backends.
+- Optimized 98-passwall hotplug script to update local IP sets quietly on non-default interfaces or ifupdate events, instead of restarting the entire service.
+---
+ .../root/etc/hotplug.d/iface/98-passwall      | 12 +++--
+ .../root/usr/share/passwall/iptables.sh       |  4 ++
+ .../root/usr/share/passwall/nftables.sh       | 50 +++++++++++++++++++
+ 3 files changed, 62 insertions(+), 4 deletions(-)
+
+diff --git a/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall b/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
+index 87638f54..09e1bda6 100644
+--- a/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
++++ b/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
+@@ -1,8 +1,8 @@
+ #!/bin/sh
+ 
+-[[ "$ACTION" == "ifup" && $(uci get "passwall.@global[0].enabled") == "1" ]] && [ -f /var/lock/passwall_ready.lock ] && {
++[[ "$ACTION" == "ifup" || "$ACTION" == "ifupdate" ]] && [[ $(uci get "passwall.@global[0].enabled") == "1" ]] && [ -f /var/lock/passwall_ready.lock ] && {
+ 	default_device=$(ip route | grep default | awk -F 'dev ' '{print $2}' | awk '{print $1}')
+-	[ "$default_device" == "$DEVICE" ] && {
++	if [ "$default_device" == "$DEVICE" ]; then
+ 		LOCK_FILE_DIR=/var/lock
+ 		[ ! -d ${LOCK_FILE_DIR} ] && mkdir -p ${LOCK_FILE_DIR}
+ 		LOCK_FILE="${LOCK_FILE_DIR}/passwall_ifup.lock"
+@@ -16,8 +16,12 @@
+ 		echo $$ > ${LOCK_FILE}
+ 		
+ 		/etc/init.d/passwall restart >/dev/null 2>&1 &
+-		logger -p notice -t network -s "passwall: restart when $INTERFACE ifup"
++		logger -p notice -t network -s "passwall: restart when default device $DEVICE $ACTION"
+ 		
+ 		rm -rf ${LOCK_FILE}
+-	}
++	else
++		# 如果是非默认接口（如 LAN 或其他 WAN 接口），仅更新本地 IP 集合，不重启服务，防止回环
++		/usr/share/passwall/nftables.sh update_local_ips >/dev/null 2>&1 &
++		logger -p notice -t network -s "passwall: update local ips when $DEVICE $ACTION"
++	fi
+ }
+diff --git a/luci-app-passwall/root/usr/share/passwall/iptables.sh b/luci-app-passwall/root/usr/share/passwall/iptables.sh
+index f399a2e0..df9ca4ed 100755
+--- a/luci-app-passwall/root/usr/share/passwall/iptables.sh
++++ b/luci-app-passwall/root/usr/share/passwall/iptables.sh
+@@ -1011,6 +1011,7 @@ add_firewall_rule() {
+ 	$ipt_m -A PSW_RULE -j CONNMARK --save-mark
+ 
+ 	$ipt_m -N PSW
++	$ipt_m -A PSW $(dst $IPSET_LOCAL) -j RETURN
+ 	$ipt_m -A PSW $(dst $IPSET_LAN) -j RETURN
+ 	$ipt_m -A PSW $(dst $IPSET_VPS) -j RETURN
+ 	$ipt_m -A PSW -m conntrack --ctdir REPLY -j RETURN
+@@ -1030,6 +1031,7 @@ add_firewall_rule() {
+ 	insert_rule_before "$ipt_m" "PREROUTING" "PSW" "-p tcp -m socket -j PSW_DIVERT"
+ 
+ 	$ipt_m -N PSW_OUTPUT
++	$ipt_m -A PSW_OUTPUT $(dst $IPSET_LOCAL) -j RETURN
+ 	$ipt_m -A PSW_OUTPUT $(dst $IPSET_LAN) -j RETURN
+ 	$ipt_m -A PSW_OUTPUT $(dst $IPSET_VPS) -j RETURN
+ 	[ -n "$IPT_APPEND_DNS" ] && {
+@@ -1090,6 +1092,7 @@ add_firewall_rule() {
+ 	$ip6t_m -A PSW_RULE -j CONNMARK --save-mark
+ 
+ 	$ip6t_m -N PSW
++	$ip6t_m -A PSW $(dst $IPSET_LOCAL6) -j RETURN
+ 	$ip6t_m -A PSW $(dst $IPSET_LAN6) -j RETURN
+ 	$ip6t_m -A PSW $(dst $IPSET_VPS6) -j RETURN
+ 	$ip6t_m -A PSW -m conntrack --ctdir REPLY -j RETURN
+@@ -1111,6 +1114,7 @@ add_firewall_rule() {
+ 
+ 	$ip6t_m -N PSW_OUTPUT
+ 	$ip6t_m -A PSW_OUTPUT -m mark --mark 255 -j RETURN
++	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_LOCAL6) -j RETURN
+ 	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_LAN6) -j RETURN
+ 	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_VPS6) -j RETURN
+ 	[ "${USE_BLOCK_LIST}" = "1" ] && $ip6t_m -A PSW_OUTPUT $(dst $IPSET_BLOCK6) -j DROP
+diff --git a/luci-app-passwall/root/usr/share/passwall/nftables.sh b/luci-app-passwall/root/usr/share/passwall/nftables.sh
+index de6b3506..0df82d56 100755
+--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
++++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
+@@ -1062,12 +1062,14 @@ add_firewall_rule() {
+ 	#ipv4 tproxy mode and udp
+ 	nft "add chain $NFTABLE_NAME PSW_MANGLE"
+ 	nft "flush chain $NFTABLE_NAME PSW_MANGLE"
++	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_LOCAL counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_LAN counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_VPS counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_MANGLE ct direction reply counter return"
+ 
+ 	nft "add chain $NFTABLE_NAME PSW_OUTPUT_MANGLE"
+ 	nft "flush chain $NFTABLE_NAME PSW_OUTPUT_MANGLE"
++	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_LOCAL counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_LAN counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_VPS counter return"
+ 	[ "${USE_BLOCK_LIST}" = "1" ] && nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_BLOCK counter drop"
+@@ -1131,12 +1133,14 @@ add_firewall_rule() {
+ 	#ipv6 tproxy mode and udp
+ 	nft "add chain $NFTABLE_NAME PSW_MANGLE_V6"
+ 	nft "flush chain $NFTABLE_NAME PSW_MANGLE_V6"
++	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_LOCAL6 counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_LAN6 counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_VPS6 counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ct direction reply counter return"
+ 
+ 	nft "add chain $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6"
+ 	nft "flush chain $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6"
++	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_LOCAL6 counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_LAN6 counter return"
+ 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_VPS6 counter return"
+ 	[ "${USE_BLOCK_LIST}" = "1" ] && nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_BLOCK6 counter drop"
+@@ -1512,9 +1516,55 @@ stop() {
+ 	flush_include
+ }
+ 
++update_local_ips() {
++	[ -z "$(command -v echolog)" ] && . /usr/share/passwall/utils.sh
++	local MY_PATH="/usr/share/passwall/nftables.sh"
++	local NFTSET_LOCAL="passwall_local"
++	local NFTSET_LOCAL6="passwall_local6"
++	local NFTSET_LAN="passwall_lan"
++	local NFTSET_LAN6="passwall_lan6"
++	local NFTSET_WAN="passwall_wan"
++	local NFTSET_WAN6="passwall_wan6"
++	local NFTABLE_NAME="inet passwall"
++	local PROXY_IPV6=$(config_t_get global_forwarding proxy_ipv6 0)
++
++	nft flush set $NFTABLE_NAME $NFTSET_LOCAL
++	ip address show | grep -w "inet" | awk '{print $2}' | awk -F '/' '{print $1}' | insert_nftset $NFTSET_LOCAL "-1"
++	
++	nft flush set $NFTABLE_NAME $NFTSET_LOCAL6
++	ip address show | grep -w "inet6" | awk '{print $2}' | awk -F '/' '{print $1}' | insert_nftset $NFTSET_LOCAL6 "-1"
++	
++	local lan_ifname=$(uci -q -p /tmp/state get network.lan.ifname)
++	[ -n "$lan_ifname" ] && {
++		nft flush set $NFTABLE_NAME $NFTSET_LAN
++		ip address show $lan_ifname | grep -w "inet" | awk '{print $2}' | insert_nftset $NFTSET_LAN "-1"
++		
++		nft flush set $NFTABLE_NAME $NFTSET_LAN6
++		ip address show $lan_ifname | grep -w "inet6" | awk '{print $2}' | insert_nftset $NFTSET_LAN6 "-1"
++	}
++	
++	WAN_IP=$(get_wan_ips ip4)
++	if [ -n "${WAN_IP}" ]; then
++		nft flush set $NFTABLE_NAME $NFTSET_WAN
++		echo $WAN_IP | insert_nftset $NFTSET_WAN "-1"
++	fi
++	
++	[ "$PROXY_IPV6" == "1" ] && {
++		WAN6_IP=$(get_wan_ips ip6)
++		if [ -n "${WAN6_IP}" ]; then
++			nft flush set $NFTABLE_NAME $NFTSET_WAN6
++			echo $WAN6_IP | insert_nftset $NFTSET_WAN6 "-1"
++		fi
++	}
++	echolog "实时更新本地和WAN IP完成。"
++}
++
+ arg1=$1
+ shift
+ case $arg1 in
++update_local_ips)
++	update_local_ips
++	;;
+ insert_nftset)
+ 	insert_nftset "$@"
+ 	;;
+-- 
+2.43.0
+

--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -194,6 +194,18 @@ rm -f $${IPKG_INSTROOT}/usr/share/passwall/rules/*.nft
 exit 0
 endef
 
+define Package/$(PKG_NAME)/postinst
+[ -n "$${IPKG_INSTROOT}" ] || {
+	if [ -s /etc/uci-defaults/luci-passwall ]; then
+		(. /etc/uci-defaults/luci-passwall) && rm -f /etc/uci-defaults/luci-passwall
+	fi
+	rm -f /tmp/luci-indexcache
+	rm -rf /tmp/luci-modulecache/
+	killall -HUP rpcd 2>/dev/null
+	exit 0
+}
+endef
+
 include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
+++ b/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
@@ -1,30 +1,76 @@
 #!/bin/sh
 
-[[ "$ACTION" == "ifup" || "$ACTION" == "ifupdate" ]] && [[ $(uci get "passwall.@global[0].enabled") == "1" ]] && [ -f /var/lock/passwall_ready.lock ] && {
-	default_device=$(ip route | grep default | awk -F 'dev ' '{print $2}' | awk '{print $1}')
-	if [ "$default_device" == "$DEVICE" ] && [ "$ACTION" == "ifup" ]; then
-		# 如果是默认出口网卡（如PPPoE拨号口）真正重新上线 (ifup)，执行完整服务重启以确保路由表和代理进程同步
-		LOCK_FILE_DIR=/var/lock
-		[ ! -d ${LOCK_FILE_DIR} ] && mkdir -p ${LOCK_FILE_DIR}
-		LOCK_FILE="${LOCK_FILE_DIR}/passwall_ifup.lock"
-		if [ -s ${LOCK_FILE} ]; then
-			SPID=$(cat ${LOCK_FILE})
-			if [ -e /proc/${SPID}/status ]; then
-				exit 1
-			fi
-			cat /dev/null > ${LOCK_FILE}
+[ "$(uci -q get passwall.@global[0].enabled)" = "1" ] || exit 0
+[ -f /var/lock/passwall_ready.lock ] || exit 0
+
+case "$ACTION" in
+ifup|ifupdate) ;;
+*) exit 0 ;;
+esac
+
+default_device=$(ip route | awk '/^default / {for (i = 1; i <= NF; i++) if ($i == "dev") {print $(i + 1); exit}}')
+[ -n "$default_device" ] || exit 0
+
+STATE_FILE=/var/run/passwall_default_device
+last_default_device=""
+[ -s "$STATE_FILE" ] && read -r last_default_device < "$STATE_FILE"
+printf '%s\n' "$default_device" > "$STATE_FILE"
+HOTPLUG_LOCK_DIR=/var/lock
+HOTPLUG_LOCK_FILE=${HOTPLUG_LOCK_DIR}/passwall_hotplug.lock
+
+run_async_once() {
+	[ ! -d "${HOTPLUG_LOCK_DIR}" ] && mkdir -p "${HOTPLUG_LOCK_DIR}"
+	if [ -s "${HOTPLUG_LOCK_FILE}" ]; then
+		local spid
+		read -r spid < "${HOTPLUG_LOCK_FILE}"
+		# 避免热插拔事件并发刷新/重启，拉长地址集合空窗。
+		if [ -n "${spid}" ] && [ -e "/proc/${spid}/status" ]; then
+			return 0
 		fi
-		echo $$ > ${LOCK_FILE}
-		
-		logger -p notice -t network -s "passwall: [检测到主路由网卡 $DEVICE $ACTION] 准备触发完整服务重启，这可能导致几秒钟的网络不可达 (Host Unreachable)"
-		/etc/init.d/passwall restart >/dev/null 2>&1 &
-		logger -p notice -t network -s "passwall: restart when default device $DEVICE $ACTION"
-		
-		rm -rf ${LOCK_FILE}
-	else
-		# 如果是非默认接口（如 LAN 或其他 WAN 接口）的变动，或者仅仅是主路由网卡的 IP 动态刷新 (ifupdate)
-		# 仅执行轻量级更新：静默刷新本地 IP 集合（nftset/ipset），不重启服务，防止打断用户当前连接，同时杜绝回环死机
-		/usr/share/passwall/nftables.sh update_local_ips >/dev/null 2>&1 &
-		logger -p notice -t network -s "passwall: update local ips when $DEVICE $ACTION"
+		: > "${HOTPLUG_LOCK_FILE}"
 	fi
+	(
+		echo $$ > "${HOTPLUG_LOCK_FILE}"
+		"$@"
+		rm -f "${HOTPLUG_LOCK_FILE}"
+	) >/dev/null 2>&1 &
 }
+
+refresh_sets() {
+	. /usr/share/passwall/utils.sh
+	eval_cache_var
+	echolog "检测到接口[${INTERFACE:-unknown}]设备[${DEVICE:-unknown}]发生${ACTION}，开始轻量刷新防火墙地址集合..."
+	case "${USE_TABLES:-}" in
+	nftables)
+		/usr/share/passwall/nftables.sh refresh_interface_nftsets >/dev/null 2>&1
+		;;
+	iptables)
+		/usr/share/passwall/iptables.sh refresh_interface_ipsets >/dev/null 2>&1
+		;;
+	*)
+		if [ "$(uci -q get passwall.@global_forwarding[0].use_nft)" = "1" ]; then
+			/usr/share/passwall/nftables.sh refresh_interface_nftsets >/dev/null 2>&1
+		else
+			/usr/share/passwall/iptables.sh refresh_interface_ipsets >/dev/null 2>&1
+		fi
+		;;
+	esac
+}
+
+if [ "$ACTION" = "ifupdate" ] || [ "$DEVICE" != "$default_device" ]; then
+	run_async_once refresh_sets
+	logger -p notice -t network -s "passwall: refresh interface sets when $INTERFACE $ACTION"
+	exit 0
+fi
+
+if [ -n "$last_default_device" ] && [ "$last_default_device" != "$default_device" ]; then
+	. /usr/share/passwall/utils.sh
+	echolog "检测到默认出口设备由[${last_default_device}]切换为[${default_device}]，执行 Passwall 完整重启..."
+	# 重启与轻量刷新共用一把锁，避免规则刷新和完整重启交错执行。
+	run_async_once /etc/init.d/passwall restart
+	logger -p notice -t network -s "passwall: restart when default device changes from ${last_default_device} to ${default_device}"
+	exit 0
+fi
+
+run_async_once refresh_sets
+logger -p notice -t network -s "passwall: refresh interface sets when default device ${default_device} ${ACTION}"

--- a/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
+++ b/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-[[ "$ACTION" == "ifup" && $(uci get "passwall.@global[0].enabled") == "1" ]] && [ -f /var/lock/passwall_ready.lock ] && {
+[[ "$ACTION" == "ifup" || "$ACTION" == "ifupdate" ]] && [[ $(uci get "passwall.@global[0].enabled") == "1" ]] && [ -f /var/lock/passwall_ready.lock ] && {
 	default_device=$(ip route | grep default | awk -F 'dev ' '{print $2}' | awk '{print $1}')
-	[ "$default_device" == "$DEVICE" ] && {
+	if [ "$default_device" == "$DEVICE" ] && [ "$ACTION" == "ifup" ]; then
+		# 如果是默认出口网卡（如PPPoE拨号口）真正重新上线 (ifup)，执行完整服务重启以确保路由表和代理进程同步
 		LOCK_FILE_DIR=/var/lock
 		[ ! -d ${LOCK_FILE_DIR} ] && mkdir -p ${LOCK_FILE_DIR}
 		LOCK_FILE="${LOCK_FILE_DIR}/passwall_ifup.lock"
@@ -15,9 +16,15 @@
 		fi
 		echo $$ > ${LOCK_FILE}
 		
+		logger -p notice -t network -s "passwall: [检测到主路由网卡 $DEVICE $ACTION] 准备触发完整服务重启，这可能导致几秒钟的网络不可达 (Host Unreachable)"
 		/etc/init.d/passwall restart >/dev/null 2>&1 &
-		logger -p notice -t network -s "passwall: restart when $INTERFACE ifup"
+		logger -p notice -t network -s "passwall: restart when default device $DEVICE $ACTION"
 		
 		rm -rf ${LOCK_FILE}
-	}
+	else
+		# 如果是非默认接口（如 LAN 或其他 WAN 接口）的变动，或者仅仅是主路由网卡的 IP 动态刷新 (ifupdate)
+		# 仅执行轻量级更新：静默刷新本地 IP 集合（nftset/ipset），不重启服务，防止打断用户当前连接，同时杜绝回环死机
+		/usr/share/passwall/nftables.sh update_local_ips >/dev/null 2>&1 &
+		logger -p notice -t network -s "passwall: update local ips when $DEVICE $ACTION"
+	fi
 }

--- a/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -107,6 +107,88 @@ destroy_ipset() {
 	done
 }
 
+replace_ipset() {
+	local ipset_name="$1"
+	local family="${2:-inet}"
+	local tmp_ipset="${ipset_name}_tmp"
+
+	if [ "$family" = "inet6" ]; then
+		ipset -! create "$tmp_ipset" nethash family inet6 maxelem 1048576
+	else
+		ipset -! create "$tmp_ipset" nethash maxelem 1048576
+	fi
+
+	ipset -F "$tmp_ipset"
+	# 先写入临时集合，再 swap，避免刷新时命中空集合。
+	{
+		if [ $# -gt 2 ]; then
+			shift 2
+			printf "%s\n" "$@"
+		else
+			cat
+		fi
+	} | while read -r addr; do
+		[ -n "$addr" ] && ipset -! add "$tmp_ipset" "$addr"
+	done
+
+	ipset -! swap "$tmp_ipset" "$ipset_name"
+	ipset -F "$tmp_ipset"
+	ipset -q -X "$tmp_ipset"
+}
+
+refresh_interface_ipsets() {
+	[ -z "$(command -v echolog)" ] && . /usr/share/passwall/utils.sh
+
+	ipset list "$IPSET_LOCAL" >/dev/null 2>&1 || return 0
+
+	local lan_ifname local_ips local6_ips lan_ips lan6_ips
+	local WAN_IP WAN6_IP wan_ip wan6_ip
+	local proxy_ipv6=$(config_t_get global_forwarding proxy_ipv6 0)
+
+	local_ips=$(ip -o -4 address show | awk '{print $4}' | awk -F '/' '{print $1}' | sort -u)
+	printf "%s\n" "$local_ips" | replace_ipset "$IPSET_LOCAL" inet
+
+	local6_ips=$(ip -o -6 address show | awk '{print $4}' | awk -F '/' '{print $1}' | sort -u)
+	printf "%s\n" "$local6_ips" | replace_ipset "$IPSET_LOCAL6" inet6
+
+	lan_ifname=$(uci -q -p /tmp/state get network.lan.device)
+	[ -z "$lan_ifname" ] && lan_ifname=$(uci -q -p /tmp/state get network.lan.ifname)
+	lan_ifname=${lan_ifname%% *}
+	if [ -n "$lan_ifname" ]; then
+		lan_ips=$(ip -o -4 address show dev "$lan_ifname" | awk '{print $4}' | sort -u)
+		printf "%s\n" "$lan_ips" | replace_ipset "$IPSET_LAN" inet
+
+		lan6_ips=$(ip -o -6 address show dev "$lan_ifname" | awk '{print $4}' | sort -u)
+		printf "%s\n" "$lan6_ips" | replace_ipset "$IPSET_LAN6" inet6
+	fi
+
+	WAN_IP=$(get_wan_ips ip4)
+	if [ -n "$WAN_IP" ]; then
+		printf "%s\n" "$WAN_IP" | replace_ipset "$IPSET_WAN" inet
+		for wan_ip in $WAN_IP; do
+			echolog "  - [$?]加入WAN IPv4到ipset[$IPSET_WAN]：${wan_ip}"
+		done
+	else
+		replace_ipset "$IPSET_WAN" inet
+	fi
+
+	if [ "$proxy_ipv6" = "1" ]; then
+		WAN6_IP=$(get_wan_ips ip6)
+		if [ -n "$WAN6_IP" ]; then
+			printf "%s\n" "$WAN6_IP" | replace_ipset "$IPSET_WAN6" inet6
+			for wan6_ip in $WAN6_IP; do
+				echolog "  - [$?]加入WAN IPv6到ipset[$IPSET_WAN6]：${wan6_ip}"
+			done
+		else
+			replace_ipset "$IPSET_WAN6" inet6
+		fi
+	else
+		replace_ipset "$IPSET_WAN6" inet6
+	fi
+
+	echolog "实时更新本地和WAN IP完成。"
+}
+
 insert_rule_before() {
 	[ $# -ge 3 ] || {
 		return 1
@@ -972,6 +1054,11 @@ add_firewall_rule() {
 	fi
 
 	$ipt_n -N PSW
+	$ipt_n -A PSW $(dst $IPSET_LOCAL) -j RETURN
+	$ipt_n -A PSW -d 127.0.0.0/8 -j RETURN
+	$ipt_n -A PSW -d 169.254.0.0/16 -j RETURN
+	$ipt_n -A PSW -d 224.0.0.0/4 -j RETURN
+	$ipt_n -A PSW -d 255.255.255.255/32 -j RETURN
 	$ipt_n -A PSW $(dst $IPSET_LAN) -j RETURN
 	$ipt_n -A PSW $(dst $IPSET_VPS) -j RETURN
 
@@ -986,6 +1073,11 @@ add_firewall_rule() {
 	[ -z "${is_tproxy}" ] && insert_rule_after "$ipt_n" "PREROUTING" "prerouting_rule" "-p tcp -j PSW"
 
 	$ipt_n -N PSW_OUTPUT
+	$ipt_n -A PSW_OUTPUT $(dst $IPSET_LOCAL) -j RETURN
+	$ipt_n -A PSW_OUTPUT -d 127.0.0.0/8 -j RETURN
+	$ipt_n -A PSW_OUTPUT -d 169.254.0.0/16 -j RETURN
+	$ipt_n -A PSW_OUTPUT -d 224.0.0.0/4 -j RETURN
+	$ipt_n -A PSW_OUTPUT -d 255.255.255.255/32 -j RETURN
 	$ipt_n -A PSW_OUTPUT $(dst $IPSET_LAN) -j RETURN
 	$ipt_n -A PSW_OUTPUT $(dst $IPSET_VPS) -j RETURN
 	[ "${USE_DIRECT_LIST}" = "1" ] && $ipt_n -A PSW_OUTPUT $(dst $IPSET_WHITE) -j RETURN
@@ -1011,8 +1103,11 @@ add_firewall_rule() {
 	$ipt_m -A PSW_RULE -j CONNMARK --save-mark
 
 	$ipt_m -N PSW
-	# 即使在旧版iptables模式下，也必须强制放行本机IP，防止地址变动回环
 	$ipt_m -A PSW $(dst $IPSET_LOCAL) -j RETURN
+	$ipt_m -A PSW -d 127.0.0.0/8 -j RETURN
+	$ipt_m -A PSW -d 169.254.0.0/16 -j RETURN
+	$ipt_m -A PSW -d 224.0.0.0/4 -j RETURN
+	$ipt_m -A PSW -d 255.255.255.255/32 -j RETURN
 	$ipt_m -A PSW $(dst $IPSET_LAN) -j RETURN
 	$ipt_m -A PSW $(dst $IPSET_VPS) -j RETURN
 	$ipt_m -A PSW -m conntrack --ctdir REPLY -j RETURN
@@ -1033,6 +1128,10 @@ add_firewall_rule() {
 
 	$ipt_m -N PSW_OUTPUT
 	$ipt_m -A PSW_OUTPUT $(dst $IPSET_LOCAL) -j RETURN
+	$ipt_m -A PSW_OUTPUT -d 127.0.0.0/8 -j RETURN
+	$ipt_m -A PSW_OUTPUT -d 169.254.0.0/16 -j RETURN
+	$ipt_m -A PSW_OUTPUT -d 224.0.0.0/4 -j RETURN
+	$ipt_m -A PSW_OUTPUT -d 255.255.255.255/32 -j RETURN
 	$ipt_m -A PSW_OUTPUT $(dst $IPSET_LAN) -j RETURN
 	$ipt_m -A PSW_OUTPUT $(dst $IPSET_VPS) -j RETURN
 	[ -n "$IPT_APPEND_DNS" ] && {
@@ -1062,11 +1161,17 @@ add_firewall_rule() {
 
 	[ "$accept_icmpv6" = "1" ] && {
 		$ip6t_n -N PSW
+		$ip6t_n -A PSW $(dst $IPSET_LOCAL6) -j RETURN
+		$ip6t_n -A PSW -d fe80::/10 -j RETURN
+		$ip6t_n -A PSW -d ff00::/8 -j RETURN
 		$ip6t_n -A PSW $(dst $IPSET_LAN6) -j RETURN
 		$ip6t_n -A PSW $(dst $IPSET_VPS6) -j RETURN
 		$ip6t_n -A PREROUTING -p ipv6-icmp -j PSW
 
 		$ip6t_n -N PSW_OUTPUT
+		$ip6t_n -A PSW_OUTPUT $(dst $IPSET_LOCAL6) -j RETURN
+		$ip6t_n -A PSW_OUTPUT -d fe80::/10 -j RETURN
+		$ip6t_n -A PSW_OUTPUT -d ff00::/8 -j RETURN
 		$ip6t_n -A PSW_OUTPUT $(dst $IPSET_LAN6) -j RETURN
 		$ip6t_n -A PSW_OUTPUT $(dst $IPSET_VPS6) -j RETURN
 		[ "${USE_DIRECT_LIST}" = "1" ] && $ip6t_n -A PSW_OUTPUT $(dst $IPSET_WHITE6) -j RETURN
@@ -1093,8 +1198,9 @@ add_firewall_rule() {
 	$ip6t_m -A PSW_RULE -j CONNMARK --save-mark
 
 	$ip6t_m -N PSW
-	# IPv6动态前缀环境下，旧版ip6tables同样需要此强制放行规则
 	$ip6t_m -A PSW $(dst $IPSET_LOCAL6) -j RETURN
+	$ip6t_m -A PSW -d fe80::/10 -j RETURN
+	$ip6t_m -A PSW -d ff00::/8 -j RETURN
 	$ip6t_m -A PSW $(dst $IPSET_LAN6) -j RETURN
 	$ip6t_m -A PSW $(dst $IPSET_VPS6) -j RETURN
 	$ip6t_m -A PSW -m conntrack --ctdir REPLY -j RETURN
@@ -1117,6 +1223,8 @@ add_firewall_rule() {
 	$ip6t_m -N PSW_OUTPUT
 	$ip6t_m -A PSW_OUTPUT -m mark --mark 255 -j RETURN
 	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_LOCAL6) -j RETURN
+	$ip6t_m -A PSW_OUTPUT -d fe80::/10 -j RETURN
+	$ip6t_m -A PSW_OUTPUT -d ff00::/8 -j RETURN
 	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_LAN6) -j RETURN
 	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_VPS6) -j RETURN
 	[ "${USE_BLOCK_LIST}" = "1" ] && $ip6t_m -A PSW_OUTPUT $(dst $IPSET_BLOCK6) -j DROP
@@ -1497,7 +1605,6 @@ get_ip6t_bin() {
 start() {
 	[ "$ENABLED_DEFAULT_ACL" == 0 -a "$ENABLED_ACLS" == 0 ] && return
 	add_firewall_rule
-	echolog "【防回环保护已激活 (iptables)】已强制直连本地所有 IPv4 和 IPv6 流量，免疫动态 IP 变动死机！"
 	gen_include
 }
 
@@ -1518,6 +1625,9 @@ stop() {
 arg1=$1
 shift
 case $arg1 in
+refresh_interface_ipsets)
+	refresh_interface_ipsets
+	;;
 RULE_LAST_INDEX)
 	RULE_LAST_INDEX "$@"
 	;;

--- a/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -1011,6 +1011,8 @@ add_firewall_rule() {
 	$ipt_m -A PSW_RULE -j CONNMARK --save-mark
 
 	$ipt_m -N PSW
+	# 即使在旧版iptables模式下，也必须强制放行本机IP，防止地址变动回环
+	$ipt_m -A PSW $(dst $IPSET_LOCAL) -j RETURN
 	$ipt_m -A PSW $(dst $IPSET_LAN) -j RETURN
 	$ipt_m -A PSW $(dst $IPSET_VPS) -j RETURN
 	$ipt_m -A PSW -m conntrack --ctdir REPLY -j RETURN
@@ -1030,6 +1032,7 @@ add_firewall_rule() {
 	insert_rule_before "$ipt_m" "PREROUTING" "PSW" "-p tcp -m socket -j PSW_DIVERT"
 
 	$ipt_m -N PSW_OUTPUT
+	$ipt_m -A PSW_OUTPUT $(dst $IPSET_LOCAL) -j RETURN
 	$ipt_m -A PSW_OUTPUT $(dst $IPSET_LAN) -j RETURN
 	$ipt_m -A PSW_OUTPUT $(dst $IPSET_VPS) -j RETURN
 	[ -n "$IPT_APPEND_DNS" ] && {
@@ -1090,6 +1093,8 @@ add_firewall_rule() {
 	$ip6t_m -A PSW_RULE -j CONNMARK --save-mark
 
 	$ip6t_m -N PSW
+	# IPv6动态前缀环境下，旧版ip6tables同样需要此强制放行规则
+	$ip6t_m -A PSW $(dst $IPSET_LOCAL6) -j RETURN
 	$ip6t_m -A PSW $(dst $IPSET_LAN6) -j RETURN
 	$ip6t_m -A PSW $(dst $IPSET_VPS6) -j RETURN
 	$ip6t_m -A PSW -m conntrack --ctdir REPLY -j RETURN
@@ -1111,6 +1116,7 @@ add_firewall_rule() {
 
 	$ip6t_m -N PSW_OUTPUT
 	$ip6t_m -A PSW_OUTPUT -m mark --mark 255 -j RETURN
+	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_LOCAL6) -j RETURN
 	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_LAN6) -j RETURN
 	$ip6t_m -A PSW_OUTPUT $(dst $IPSET_VPS6) -j RETURN
 	[ "${USE_BLOCK_LIST}" = "1" ] && $ip6t_m -A PSW_OUTPUT $(dst $IPSET_BLOCK6) -j DROP
@@ -1491,6 +1497,7 @@ get_ip6t_bin() {
 start() {
 	[ "$ENABLED_DEFAULT_ACL" == 0 -a "$ENABLED_ACLS" == 0 ] && return
 	add_firewall_rule
+	echolog "【防回环保护已激活 (iptables)】已强制直连本地所有 IPv4 和 IPv6 流量，免疫动态 IP 变动死机！"
 	gen_include
 }
 

--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -200,6 +200,103 @@ insert_nftset() {
 	fi
 }
 
+replace_nftset() {
+	local nftset_name="${1}"; shift
+	local timeout_argument="${1}"; shift
+	local default_timeout="365d"
+	local suffix=""
+
+	case "$timeout_argument" in
+		"-1") suffix="" ;;
+		 "0") suffix=" timeout $default_timeout" ;;
+		   *) suffix=" timeout $timeout_argument" ;;
+	esac
+
+	# 用同一笔 nft 事务替换集合成员，避免刷新时集合短暂为空。
+	{
+		printf "flush set %s %s\n" "$NFTABLE_NAME" "$nftset_name"
+		if [ $# -gt 0 ] || [ ! -t 0 ]; then
+			{
+				if [ $# -gt 0 ]; then
+					printf "%s\n" "$@"
+				else
+					cat
+				fi | tr -s ' \t' '\n' | awk -v s="$suffix" -v n="$nftset_name" -v t="$NFTABLE_NAME" '
+					{
+						gsub(/^[ \t\r]+|[ \t\r]+$/, "");
+					}
+					$0 != "" {
+						if (first == 0) {
+							printf "add element %s %s { \n", t, n;
+							first = 1;
+						} else {
+							printf ",\n";
+						}
+						printf "%s%s", $0, s;
+					}
+					END {
+						if (first == 1) printf "\n }\n";
+					}
+				'
+			}
+		fi
+	} | nft -f -
+}
+
+refresh_interface_nftsets() {
+	[ -z "$(command -v echolog)" ] && . /usr/share/passwall/utils.sh
+
+	nft list table "$NFTABLE_NAME" >/dev/null 2>&1 || return 0
+	nft list set "$NFTABLE_NAME" "$NFTSET_LOCAL" >/dev/null 2>&1 || return 0
+
+	local lan_ifname local_ips local6_ips lan_ips lan6_ips
+	local WAN_IP WAN6_IP wan_ip wan6_ip
+	local proxy_ipv6=$(config_t_get global_forwarding proxy_ipv6 0)
+
+	local_ips=$(ip -o -4 address show | awk '{print $4}' | awk -F '/' '{print $1}' | sort -u)
+	printf "%s\n" "$local_ips" | replace_nftset "$NFTSET_LOCAL" "-1"
+
+	local6_ips=$(ip -o -6 address show | awk '{print $4}' | awk -F '/' '{print $1}' | sort -u)
+	printf "%s\n" "$local6_ips" | replace_nftset "$NFTSET_LOCAL6" "-1"
+
+	lan_ifname=$(uci -q -p /tmp/state get network.lan.device)
+	[ -z "$lan_ifname" ] && lan_ifname=$(uci -q -p /tmp/state get network.lan.ifname)
+	lan_ifname=${lan_ifname%% *}
+	if [ -n "$lan_ifname" ]; then
+		lan_ips=$(ip -o -4 address show dev "$lan_ifname" | awk '{print $4}' | sort -u)
+		printf "%s\n" "$lan_ips" | replace_nftset "$NFTSET_LAN" "-1"
+
+		lan6_ips=$(ip -o -6 address show dev "$lan_ifname" | awk '{print $4}' | sort -u)
+		printf "%s\n" "$lan6_ips" | replace_nftset "$NFTSET_LAN6" "-1"
+	fi
+
+	WAN_IP=$(get_wan_ips ip4)
+	if [ -n "$WAN_IP" ]; then
+		printf "%s\n" $WAN_IP | replace_nftset "$NFTSET_WAN" "-1"
+		for wan_ip in $WAN_IP; do
+			echolog "  - [$?]加入WAN IPv4到nftset[$NFTSET_WAN]：${wan_ip}"
+		done
+	else
+		replace_nftset "$NFTSET_WAN" "-1"
+	fi
+
+	if [ "$proxy_ipv6" = "1" ]; then
+		WAN6_IP=$(get_wan_ips ip6)
+		if [ -n "$WAN6_IP" ]; then
+			printf "%s\n" $WAN6_IP | replace_nftset "$NFTSET_WAN6" "-1"
+			for wan6_ip in $WAN6_IP; do
+				echolog "  - [$?]加入WAN IPv6到nftset[$NFTSET_WAN6]：${wan6_ip}"
+			done
+		else
+			replace_nftset "$NFTSET_WAN6" "-1"
+		fi
+	else
+		replace_nftset "$NFTSET_WAN6" "-1"
+	fi
+
+	echolog "实时更新本地和WAN IP完成。"
+}
+
 gen_nftset() {
 	local nftset_name="${1}"; shift
 	local ip_type="${1}"; shift
@@ -1062,16 +1159,22 @@ add_firewall_rule() {
 	#ipv4 tproxy mode and udp
 	nft "add chain $NFTABLE_NAME PSW_MANGLE"
 	nft "flush chain $NFTABLE_NAME PSW_MANGLE"
-	# 强制直连本地和局域网流量，防止在IP变动时因规则未刷新导致流量被错误代理而引发无限回环死机
 	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_LOCAL counter return"
+	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr 127.0.0.0/8 counter return"
+	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr 169.254.0.0/16 counter return"
+	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr 224.0.0.0/4 counter return"
+	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr 255.255.255.255 counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_LAN counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_VPS counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE ct direction reply counter return"
 
 	nft "add chain $NFTABLE_NAME PSW_OUTPUT_MANGLE"
 	nft "flush chain $NFTABLE_NAME PSW_OUTPUT_MANGLE"
-	# 路由器本机输出流量同样需要强制直连本地地址，杜绝回环
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_LOCAL counter return"
+	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr 127.0.0.0/8 counter return"
+	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr 169.254.0.0/16 counter return"
+	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr 224.0.0.0/4 counter return"
+	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr 255.255.255.255 counter return"
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_LAN counter return"
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_VPS counter return"
 	[ "${USE_BLOCK_LIST}" = "1" ] && nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_BLOCK counter drop"
@@ -1088,12 +1191,22 @@ add_firewall_rule() {
 	[ -z "${is_tproxy}" ] && {
 		nft "add chain $NFTABLE_NAME PSW_NAT"
 		nft "flush chain $NFTABLE_NAME PSW_NAT"
+		nft "add rule $NFTABLE_NAME PSW_NAT ip daddr @$NFTSET_LOCAL counter return"
+		nft "add rule $NFTABLE_NAME PSW_NAT ip daddr 127.0.0.0/8 counter return"
+		nft "add rule $NFTABLE_NAME PSW_NAT ip daddr 169.254.0.0/16 counter return"
+		nft "add rule $NFTABLE_NAME PSW_NAT ip daddr 224.0.0.0/4 counter return"
+		nft "add rule $NFTABLE_NAME PSW_NAT ip daddr 255.255.255.255 counter return"
 		nft "add rule $NFTABLE_NAME PSW_NAT ip daddr @$NFTSET_LAN counter return"
 		nft "add rule $NFTABLE_NAME PSW_NAT ip daddr @$NFTSET_VPS counter return"
 		nft "add rule $NFTABLE_NAME dstnat ip protocol tcp counter jump PSW_NAT"
 
 		nft "add chain $NFTABLE_NAME PSW_OUTPUT_NAT"
 		nft "flush chain $NFTABLE_NAME PSW_OUTPUT_NAT"
+		nft "add rule $NFTABLE_NAME PSW_OUTPUT_NAT ip daddr @$NFTSET_LOCAL counter return"
+		nft "add rule $NFTABLE_NAME PSW_OUTPUT_NAT ip daddr 127.0.0.0/8 counter return"
+		nft "add rule $NFTABLE_NAME PSW_OUTPUT_NAT ip daddr 169.254.0.0/16 counter return"
+		nft "add rule $NFTABLE_NAME PSW_OUTPUT_NAT ip daddr 224.0.0.0/4 counter return"
+		nft "add rule $NFTABLE_NAME PSW_OUTPUT_NAT ip daddr 255.255.255.255 counter return"
 		nft "add rule $NFTABLE_NAME PSW_OUTPUT_NAT ip daddr @$NFTSET_LAN counter return"
 		nft "add rule $NFTABLE_NAME PSW_OUTPUT_NAT ip daddr @$NFTSET_VPS counter return"
 		[ "${USE_BLOCK_LIST}" = "1" ] && nft "add rule $NFTABLE_NAME PSW_OUTPUT_NAT ip daddr @$NFTSET_BLOCK counter drop"
@@ -1105,10 +1218,18 @@ add_firewall_rule() {
 	if [ "$accept_icmp" = "1" ]; then
 		nft "add chain $NFTABLE_NAME PSW_ICMP_REDIRECT"
 		nft "flush chain $NFTABLE_NAME PSW_ICMP_REDIRECT"
+		nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip daddr @$NFTSET_LOCAL counter return"
+		nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip daddr 127.0.0.0/8 counter return"
+		nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip daddr 169.254.0.0/16 counter return"
+		nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip daddr 224.0.0.0/4 counter return"
+		nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip daddr 255.255.255.255 counter return"
 		nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip daddr @$NFTSET_LAN counter return"
 		nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip daddr @$NFTSET_VPS counter return"
 
 		[ "$accept_icmpv6" = "1" ] && {
+			nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip6 daddr @$NFTSET_LOCAL6 counter return"
+			nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip6 daddr fe80::/10 counter return"
+			nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip6 daddr ff00::/8 counter return"
 			nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip6 daddr @$NFTSET_LAN6 counter return"
 			nft "add rule $NFTABLE_NAME PSW_ICMP_REDIRECT ip6 daddr @$NFTSET_VPS6 counter return"
 		}
@@ -1135,16 +1256,18 @@ add_firewall_rule() {
 	#ipv6 tproxy mode and udp
 	nft "add chain $NFTABLE_NAME PSW_MANGLE_V6"
 	nft "flush chain $NFTABLE_NAME PSW_MANGLE_V6"
-	# IPv6前缀经常动态变动，强制放行发往本机的流量是防止“变动即死机”的核心修复
 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_LOCAL6 counter return"
+	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr fe80::/10 counter return"
+	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr ff00::/8 counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_LAN6 counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_VPS6 counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ct direction reply counter return"
 
 	nft "add chain $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6"
 	nft "flush chain $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6"
-	# 本机输出链同样强制直连本机IPv6，防止拦截本机产生的响应包
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_LOCAL6 counter return"
+	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr fe80::/10 counter return"
+	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr ff00::/8 counter return"
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_LAN6 counter return"
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_VPS6 counter return"
 	[ "${USE_BLOCK_LIST}" = "1" ] && nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_BLOCK6 counter drop"
@@ -1502,8 +1625,6 @@ gen_include() {
 start() {
 	[ "$ENABLED_DEFAULT_ACL" == 0 -a "$ENABLED_ACLS" == 0 ] && return
 	add_firewall_rule
-	update_local_ips
-	echolog "【防回环保护已激活】已强制直连本地所有 IPv4 和 IPv6 流量，免疫动态 IP 变动死机！"
 	gen_include
 }
 
@@ -1522,58 +1643,11 @@ stop() {
 	flush_include
 }
 
-update_local_ips() {
-	[ -z "$(command -v echolog)" ] && . /usr/share/passwall/utils.sh
-	local MY_PATH="/usr/share/passwall/nftables.sh"
-	local NFTSET_LOCAL="passwall_local"
-	local NFTSET_LOCAL6="passwall_local6"
-	local NFTSET_LAN="passwall_lan"
-	local NFTSET_LAN6="passwall_lan6"
-	local NFTSET_WAN="passwall_wan"
-	local NFTSET_WAN6="passwall_wan6"
-	local NFTABLE_NAME="inet passwall"
-	local PROXY_IPV6=$(config_t_get global_forwarding proxy_ipv6 0)
-
-	nft flush set $NFTABLE_NAME $NFTSET_LOCAL
-	local local_ips=$(ip address show | grep -w "inet" | awk '{print $2}' | awk -F '/' '{print $1}')
-	echo "$local_ips" | insert_nftset $NFTSET_LOCAL "-1"
-	[ -n "$local_ips" ] && echolog "  - [$?]加入本地 IPv4 到 nftset[$NFTSET_LOCAL]"
-	
-	nft flush set $NFTABLE_NAME $NFTSET_LOCAL6
-	local local6_ips=$(ip address show | grep -w "inet6" | awk '{print $2}' | awk -F '/' '{print $1}')
-	echo "$local6_ips" | insert_nftset $NFTSET_LOCAL6 "-1"
-	[ -n "$local6_ips" ] && echolog "  - [$?]加入本地 IPv6 到 nftset[$NFTSET_LOCAL6]"
-	
-	local lan_ifname=$(uci -q -p /tmp/state get network.lan.ifname)
-	[ -n "$lan_ifname" ] && {
-		nft flush set $NFTABLE_NAME $NFTSET_LAN
-		ip address show $lan_ifname | grep -w "inet" | awk '{print $2}' | insert_nftset $NFTSET_LAN "-1"
-		
-		nft flush set $NFTABLE_NAME $NFTSET_LAN6
-		ip address show $lan_ifname | grep -w "inet6" | awk '{print $2}' | insert_nftset $NFTSET_LAN6 "-1"
-	}
-	
-	WAN_IP=$(get_wan_ips ip4)
-	if [ -n "${WAN_IP}" ]; then
-		nft flush set $NFTABLE_NAME $NFTSET_WAN
-		echo $WAN_IP | insert_nftset $NFTSET_WAN "-1"
-	fi
-	
-	[ "$PROXY_IPV6" == "1" ] && {
-		WAN6_IP=$(get_wan_ips ip6)
-		if [ -n "${WAN6_IP}" ]; then
-			nft flush set $NFTABLE_NAME $NFTSET_WAN6
-			echo $WAN6_IP | insert_nftset $NFTSET_WAN6 "-1"
-		fi
-	}
-	echolog "实时更新本地和WAN IP完成。"
-}
-
 arg1=$1
 shift
 case $arg1 in
-update_local_ips)
-	update_local_ips
+refresh_interface_nftsets)
+	refresh_interface_nftsets
 	;;
 insert_nftset)
 	insert_nftset "$@"

--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -1062,12 +1062,16 @@ add_firewall_rule() {
 	#ipv4 tproxy mode and udp
 	nft "add chain $NFTABLE_NAME PSW_MANGLE"
 	nft "flush chain $NFTABLE_NAME PSW_MANGLE"
+	# 强制直连本地和局域网流量，防止在IP变动时因规则未刷新导致流量被错误代理而引发无限回环死机
+	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_LOCAL counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_LAN counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE ip daddr @$NFTSET_VPS counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE ct direction reply counter return"
 
 	nft "add chain $NFTABLE_NAME PSW_OUTPUT_MANGLE"
 	nft "flush chain $NFTABLE_NAME PSW_OUTPUT_MANGLE"
+	# 路由器本机输出流量同样需要强制直连本地地址，杜绝回环
+	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_LOCAL counter return"
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_LAN counter return"
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_VPS counter return"
 	[ "${USE_BLOCK_LIST}" = "1" ] && nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE ip daddr @$NFTSET_BLOCK counter drop"
@@ -1131,12 +1135,16 @@ add_firewall_rule() {
 	#ipv6 tproxy mode and udp
 	nft "add chain $NFTABLE_NAME PSW_MANGLE_V6"
 	nft "flush chain $NFTABLE_NAME PSW_MANGLE_V6"
+	# IPv6前缀经常动态变动，强制放行发往本机的流量是防止“变动即死机”的核心修复
+	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_LOCAL6 counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_LAN6 counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ip6 daddr @$NFTSET_VPS6 counter return"
 	nft "add rule $NFTABLE_NAME PSW_MANGLE_V6 ct direction reply counter return"
 
 	nft "add chain $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6"
 	nft "flush chain $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6"
+	# 本机输出链同样强制直连本机IPv6，防止拦截本机产生的响应包
+	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_LOCAL6 counter return"
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_LAN6 counter return"
 	nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_VPS6 counter return"
 	[ "${USE_BLOCK_LIST}" = "1" ] && nft "add rule $NFTABLE_NAME PSW_OUTPUT_MANGLE_V6 ip6 daddr @$NFTSET_BLOCK6 counter drop"
@@ -1494,6 +1502,8 @@ gen_include() {
 start() {
 	[ "$ENABLED_DEFAULT_ACL" == 0 -a "$ENABLED_ACLS" == 0 ] && return
 	add_firewall_rule
+	update_local_ips
+	echolog "【防回环保护已激活】已强制直连本地所有 IPv4 和 IPv6 流量，免疫动态 IP 变动死机！"
 	gen_include
 }
 
@@ -1512,9 +1522,59 @@ stop() {
 	flush_include
 }
 
+update_local_ips() {
+	[ -z "$(command -v echolog)" ] && . /usr/share/passwall/utils.sh
+	local MY_PATH="/usr/share/passwall/nftables.sh"
+	local NFTSET_LOCAL="passwall_local"
+	local NFTSET_LOCAL6="passwall_local6"
+	local NFTSET_LAN="passwall_lan"
+	local NFTSET_LAN6="passwall_lan6"
+	local NFTSET_WAN="passwall_wan"
+	local NFTSET_WAN6="passwall_wan6"
+	local NFTABLE_NAME="inet passwall"
+	local PROXY_IPV6=$(config_t_get global_forwarding proxy_ipv6 0)
+
+	nft flush set $NFTABLE_NAME $NFTSET_LOCAL
+	local local_ips=$(ip address show | grep -w "inet" | awk '{print $2}' | awk -F '/' '{print $1}')
+	echo "$local_ips" | insert_nftset $NFTSET_LOCAL "-1"
+	[ -n "$local_ips" ] && echolog "  - [$?]加入本地 IPv4 到 nftset[$NFTSET_LOCAL]"
+	
+	nft flush set $NFTABLE_NAME $NFTSET_LOCAL6
+	local local6_ips=$(ip address show | grep -w "inet6" | awk '{print $2}' | awk -F '/' '{print $1}')
+	echo "$local6_ips" | insert_nftset $NFTSET_LOCAL6 "-1"
+	[ -n "$local6_ips" ] && echolog "  - [$?]加入本地 IPv6 到 nftset[$NFTSET_LOCAL6]"
+	
+	local lan_ifname=$(uci -q -p /tmp/state get network.lan.ifname)
+	[ -n "$lan_ifname" ] && {
+		nft flush set $NFTABLE_NAME $NFTSET_LAN
+		ip address show $lan_ifname | grep -w "inet" | awk '{print $2}' | insert_nftset $NFTSET_LAN "-1"
+		
+		nft flush set $NFTABLE_NAME $NFTSET_LAN6
+		ip address show $lan_ifname | grep -w "inet6" | awk '{print $2}' | insert_nftset $NFTSET_LAN6 "-1"
+	}
+	
+	WAN_IP=$(get_wan_ips ip4)
+	if [ -n "${WAN_IP}" ]; then
+		nft flush set $NFTABLE_NAME $NFTSET_WAN
+		echo $WAN_IP | insert_nftset $NFTSET_WAN "-1"
+	fi
+	
+	[ "$PROXY_IPV6" == "1" ] && {
+		WAN6_IP=$(get_wan_ips ip6)
+		if [ -n "${WAN6_IP}" ]; then
+			nft flush set $NFTABLE_NAME $NFTSET_WAN6
+			echo $WAN6_IP | insert_nftset $NFTSET_WAN6 "-1"
+		fi
+	}
+	echolog "实时更新本地和WAN IP完成。"
+}
+
 arg1=$1
 shift
 case $arg1 in
+update_local_ips)
+	update_local_ips
+	;;
 insert_nftset)
 	insert_nftset "$@"
 	;;


### PR DESCRIPTION
### 问题描述 
在动态 IPv6 环境， Passwall 的 TPROXY 模式存在回环漏洞：
当路由器的本地 IP，特别是 IPv6
发生变动
且有流量访问该新 IP 时
由于未在拦截链顶端豁免本机 IP，流量会被交给代理软件
代理软件发出后再次被防火墙拦截，引发无限回环
导致路由器 CPU 瞬间 100%、断网死机。

### 修复方案 
1. **强制直连本地流量**：在 IPv4 和 IPv6 的所有 `MANGLE` 和 `OUTPUT_MANGLE` 链（涵盖 nftables 和旧版 iptables）的最顶端，加入了对 `passwall_local(6)` 和 `passwall_lan(6)` 集合的强制 `counter return` 规则，从物理层面彻底切断回环产生的可能。
2. **轻量级动态刷新**：优化了 `/etc/hotplug.d/iface/98-passwall`。对于非默认路由网卡的变动或单纯的 `ifupdate` 事件，不再粗暴地重启整个 passwall 服务，而是通过新增的 `update_local_ips` 函数静默且秒级地刷新底层的本地 IP 集合。
3. **完善初始加载**：修复了原版在 `start()` 时未及时加载本地 IPv6 集合的疏漏，确保开机第一秒防御规则即生效。

https://github.com/Openwrt-Passwall/openwrt-passwall/issues/4328