### PR TITLE
luci: optimize rule update domain matching

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/rule_update.lua
+++ b/luci-app-passwall/root/usr/share/passwall/rule_update.lua
@@ -440,7 +440,7 @@ local function fetch_rule(rule_name, rule_type, url, exclude_domain, max_retries
 						line = line:gsub("full:", "")
 						if not (is_comment_line(line) or is_ipv4(line) or has_colon(line) or (exclude_domain and check_excluded_domain(line))) then
 							local match = extract_domain(line)
-							if match then
+							if match and not is_ipv4(match) then
 								rule_dataset[match] = true
 							end
 						end
@@ -451,7 +451,7 @@ local function fetch_rule(rule_name, rule_type, url, exclude_domain, max_retries
 							line = line:gsub("full:", "")
 							if not (is_comment_line(line) or is_ipv4(line) or has_colon(line) or (exclude_domain and check_excluded_domain(line))) then
 								local match = extract_domain(line)
-								if match then
+								if match and not is_ipv4(match) then
 									rule_dataset[match] = true
 								end
 							end


### PR DESCRIPTION
当前域名提取函数 `extract_domain` 在遇到以下规则时，会被提取为 `114.114.114.114` 更新到 `chnlist` 列表，虽然当前运行没有异常，但逻辑上来说不应该将 IP 加到域名列表。

```conf
server=/cn/114.114.114.114
server=/top/114.114.114.114
server=/wang/114.114.114.114
server=/xn--55qx5d/114.114.114.114
server=/xn--fiqs8s/114.114.114.114
server=/xn--io0a7i/114.114.114.114
```

查看当前域名匹配条件及历史 commits 中的匹配条件，passwall 更新规则时会过滤掉顶级域（即必须要有一个点才算合法域名），避免匹配范围过于宽泛，所以不对匹配条件进行修改，使用 `is_ipv4` 函数来过滤掉 IP。