### PR TITLE
luci: optimize

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -1023,9 +1023,9 @@ add_firewall_rule() {
 	$ipt_n -N PSW_DNS
 	if [ $(config_t_get global dns_redirect "1") = "0" ]; then
 		#Only hijack when dest address is local IP
-		$ipt_n -I PREROUTING $(dst $IPSET_LOCAL) -j PSW_DNS
+		$ipt_n -I PREROUTING -m set --match-set $IPSET_LAN src $(dst $IPSET_LOCAL) -j PSW_DNS
 	else
-		$ipt_n -I PREROUTING 1 -j PSW_DNS
+		$ipt_n -I PREROUTING -m set --match-set $IPSET_LAN src -j PSW_DNS
 	fi
 
 	$ipt_m -N PSW_DIVERT
@@ -1094,9 +1094,9 @@ add_firewall_rule() {
 	$ip6t_n -N PSW_DNS
 	if [ $(config_t_get global dns_redirect "1") = "0" ]; then
 		#Only hijack when dest address is local IP
-		$ip6t_n -I PREROUTING $(dst $IPSET_LOCAL6) -j PSW_DNS
+		$ip6t_n -I PREROUTING -m set --match-set $IPSET_LAN6 src $(dst $IPSET_LOCAL6) -j PSW_DNS
 	else
-		$ip6t_n -I PREROUTING 1 -j PSW_DNS
+		$ip6t_n -I PREROUTING -m set --match-set $IPSET_LAN6 src -j PSW_DNS
 	fi
 
 	$ip6t_m -N PSW_DIVERT

--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -1074,10 +1074,11 @@ add_firewall_rule() {
 	nft "flush chain $NFTABLE_NAME PSW_DNS"
 	if [ $(config_t_get global dns_redirect "1") = "0" ]; then
 		#Only hijack when dest address is local IP
-		nft "insert rule $NFTABLE_NAME dstnat ip daddr @${NFTSET_LOCAL} jump PSW_DNS"
-		nft "insert rule $NFTABLE_NAME dstnat ip6 daddr @${NFTSET_LOCAL6} jump PSW_DNS"
+		nft "insert rule $NFTABLE_NAME dstnat ip saddr @${NFTSET_LAN} ip daddr @${NFTSET_LOCAL} jump PSW_DNS"
+		nft "insert rule $NFTABLE_NAME dstnat ip6 saddr @${NFTSET_LAN6} ip6 daddr @${NFTSET_LOCAL6} jump PSW_DNS"
 	else
-		nft "insert rule $NFTABLE_NAME dstnat jump PSW_DNS"
+		nft "insert rule $NFTABLE_NAME dstnat ip saddr @${NFTSET_LAN} jump PSW_DNS"
+		nft "insert rule $NFTABLE_NAME dstnat ip6 saddr @${NFTSET_LAN6} jump PSW_DNS"
 	fi
 
 	# for ipv4 ipv6 tproxy mark


### PR DESCRIPTION
#4343

@bcseputetto 与用户 @jjlizz 沟通后发现，开启 Full Cone NAT 后，WAN 方向 53 端口是通的。
@bcseputetto 进一步分析发现，ImmortalWrt 的 Full Cone NAT 会在防火墙同时加入 `srcnat_wan fullcone` 和 `dstnat_wan fullcone` 规则，某些固件只在防火墙加入 `srcnat_wan fullcone` 则不会有此问题。

该优化方案来自 Gemini 3.1 Pro 模型，fw4 环境下测试符合预期（WAN 方向 53 端口不通），fw3 环境未测试。