### PR TITLE
luci: optimize the performance of check_excluded_domain

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq.lua
+++ b/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq.lua
@@ -286,17 +286,22 @@ function add_rule(var)
 		if domain == "" or domain:find("#") then
 			return
 		end
-		table.insert(excluded_domain, domain)
+		excluded_domain[domain] = true
 	end
 
 	local function check_excluded_domain(domain)
 		if domain == "" or domain:find("#") then
 			return false
 		end
-		for k,v in ipairs(excluded_domain) do
-			if domain == v or domain:sub(-#("."..v)) == "."..v then
+		if excluded_domain[domain] then
+			return true
+		end
+		local pos = domain:find(".", 1, true)
+		while pos do
+			if excluded_domain[domain:sub(pos + 1)] then
 				return true
 			end
+			pos = domain:find(".", pos + 1, true)
 		end
 		return false
 	end


### PR DESCRIPTION
The time complexity is reduced from O(n) to O(1).


当用户自定义的域名黑白名单（直连/代理列表）近200个时，check_excluded_domain的复杂度会让chnroute列表的生成时间达到30秒（在rk3568上）。
优化后，只需要3秒。用户自定义的域名数量越多，优化效果越明显。

以下是优化前后的日志：
优化前：
```
2026-04-29 14:17:49:   - 代理域名表(blacklist)：127.0.0.53#53
2026-04-29 14:17:50:   - 防火墙域名表(gfwlist)：127.0.0.53#53
2026-04-29 14:18:21:   - 中国域名表(chnroute)：默认
2026-04-29 14:18:24:   - 默认：127.0.0.55#53
```

优化后：
```
2026-04-29 14:24:08:   - 代理域名表(blacklist)：127.0.0.53#53
2026-04-29 14:24:09:   - 防火墙域名表(gfwlist)：127.0.0.53#53
2026-04-29 14:24:11:   - 中国域名表(chnroute)：默认
2026-04-29 14:24:14:   - 默认：127.0.0.55#53
```

已验证修改前后生成的 /tmp/etc/passwall/acl/default/dnsmasq.d 文件夹内容完全一致。
