### PR TITLE
fix: preserve tcp_proxy_mode=direct and prevent Rule List data loss

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/rule_list.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/rule_list.lua
@@ -48,8 +48,8 @@ o.write = function(self, section, value)
 	sys.call("rm -rf /tmp/etc/passwall_tmp/dns_*")
 end
 o.remove = function(self, section, value)
-	fs.writefile(direct_host, "")
-	sys.call("rm -rf /tmp/etc/passwall_tmp/dns_*")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
+	-- does not mean the user cleared the content
 end
 o.validate = function(self, value)
 	local hosts= {}
@@ -77,7 +77,7 @@ o.write = function(self, section, value)
 	fs.writefile(direct_ip, value:gsub("\r\n", "\n"))
 end
 o.remove = function(self, section, value)
-	fs.writefile(direct_ip, "")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
 end
 o.validate = function(self, value)
 	local ipmasks= {}
@@ -106,8 +106,7 @@ o.write = function(self, section, value)
 	sys.call("rm -rf /tmp/etc/passwall_tmp/dns_*")
 end
 o.remove = function(self, section, value)
-	fs.writefile(proxy_host, "")
-	sys.call("rm -rf /tmp/etc/passwall_tmp/dns_*")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
 end
 o.validate = function(self, value)
 	local hosts= {}
@@ -135,7 +134,7 @@ o.write = function(self, section, value)
 	fs.writefile(proxy_ip, value:gsub("\r\n", "\n"))
 end
 o.remove = function(self, section, value)
-	fs.writefile(proxy_ip, "")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
 end
 o.validate = function(self, value)
 	local ipmasks= {}
@@ -163,7 +162,7 @@ o.write = function(self, section, value)
 	fs.writefile(block_host, value:gsub("\r\n", "\n"))
 end
 o.remove = function(self, section, value)
-	fs.writefile(block_host, "")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
 end
 o.validate = function(self, value)
 	local hosts= {}
@@ -191,7 +190,7 @@ o.write = function(self, section, value)
 	fs.writefile(block_ip, value:gsub("\r\n", "\n"))
 end
 o.remove = function(self, section, value)
-	fs.writefile(block_ip, "")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
 end
 o.validate = function(self, value)
 	local ipmasks= {}
@@ -219,7 +218,7 @@ o.write = function(self, section, value)
 	fs.writefile(lanlist_ipv4, value:gsub("\r\n", "\n"))
 end
 o.remove = function(self, section, value)
-	fs.writefile(lanlist_ipv4, "")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
 end
 o.validate = function(self, value)
 	local ipmasks= {}
@@ -247,7 +246,7 @@ o.write = function(self, section, value)
 	fs.writefile(lanlist_ipv6, value:gsub("\r\n", "\n"))
 end
 o.remove = function(self, section, value)
-	fs.writefile(lanlist_ipv6, "")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
 end
 o.validate = function(self, value)
 	local ipmasks= {}
@@ -275,7 +274,7 @@ o.write = function(self, section, value)
 	fs.writefile(hosts, clean_text(value))
 end
 o.remove = function(self, section, value)
-	fs.writefile(hosts, "")
+	-- no-op: field absent from POST due to JS-LuCI lazy tab loading
 end
 
 if fs.access(gfwlist_path) then

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1986,8 +1986,8 @@ get_config() {
 	CHN_LIST=$(config_t_get global chn_list direct)
 	TCP_PROXY_MODE=$(config_t_get global tcp_proxy_mode proxy)
 	UDP_PROXY_MODE=$(config_t_get global udp_proxy_mode proxy)
-	[ "${TCP_PROXY_MODE}" != "disable" ] && TCP_PROXY_MODE="proxy"
-	[ "${UDP_PROXY_MODE}" != "disable" ] && UDP_PROXY_MODE="proxy"
+	[ "${TCP_PROXY_MODE}" != "disable" ] && [ "${TCP_PROXY_MODE}" != "direct" ] && TCP_PROXY_MODE="proxy"
+	[ "${UDP_PROXY_MODE}" != "disable" ] && [ "${UDP_PROXY_MODE}" != "direct" ] && UDP_PROXY_MODE="proxy"
 	LOCALHOST_PROXY=$(config_t_get global localhost_proxy 1)
 	[ "${LOCALHOST_PROXY}" == 1 ] && {
 		LOCALHOST_TCP_PROXY_MODE=$TCP_PROXY_MODE

--- a/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -670,7 +670,7 @@ load_acl() {
 				[ "${USE_GFW_LIST}" = "1" ] && add_port_rules "$ipt_tmp -A PSW $(comment "默认") -p tcp" $TCP_REDIR_PORTS "$(dst $IPSET_GFW) ${ipt_j}"
 				[ "${CHN_LIST}" != "0" ] && add_port_rules "$ipt_tmp -A PSW $(comment "默认") -p tcp" $TCP_REDIR_PORTS "$(dst $IPSET_CHN) $(get_jump_ipt ${CHN_LIST} "${ipt_j}")"
 				[ "${USE_SHUNT_TCP}" = "1" ] && add_port_rules "$ipt_tmp -A PSW $(comment "默认") -p tcp" $TCP_REDIR_PORTS "$(dst $IPSET_SHUNT) ${ipt_j}"
-				[ "${TCP_PROXY_MODE}" != "disable" ] && add_port_rules "$ipt_tmp -A PSW $(comment "默认") -p tcp" $TCP_REDIR_PORTS "${ipt_j}"
+				[ "${TCP_PROXY_MODE}" != "disable" ] && add_port_rules "$ipt_tmp -A PSW $(comment "默认") -p tcp" $TCP_REDIR_PORTS "$(get_jump_ipt ${TCP_PROXY_MODE} "${ipt_j}")"
 				[ -n "${is_tproxy}" ]&& $ipt_tmp -A PSW $(comment "默认") -p tcp $(REDIRECT $TCP_REDIR_PORT TPROXY)
 
 				[ "$PROXY_IPV6" == "1" ] && {
@@ -1253,7 +1253,7 @@ add_firewall_rule() {
 				[ "${USE_GFW_LIST}" = "1" ] && add_port_rules "$ipt_tmp -A PSW_OUTPUT -p tcp" $TCP_REDIR_PORTS "$(dst $IPSET_GFW) ${ipt_j}"
 				[ "${CHN_LIST}" != "0" ] && add_port_rules "$ipt_tmp -A PSW_OUTPUT -p tcp" $TCP_REDIR_PORTS "$(dst $IPSET_CHN) $(get_jump_ipt ${CHN_LIST} "${ipt_j}")"
 				[ "${USE_SHUNT_TCP}" = "1" ] && add_port_rules "$ipt_tmp -A PSW_OUTPUT -p tcp" $TCP_REDIR_PORTS "$(dst $IPSET_SHUNT) ${ipt_j}"
-				[ "${LOCALHOST_TCP_PROXY_MODE}" != "disable" ] && add_port_rules "$ipt_tmp -A PSW_OUTPUT -p tcp" $TCP_REDIR_PORTS "${ipt_j}"
+				[ "${LOCALHOST_TCP_PROXY_MODE}" != "disable" ] && add_port_rules "$ipt_tmp -A PSW_OUTPUT -p tcp" $TCP_REDIR_PORTS "$(get_jump_ipt ${LOCALHOST_TCP_PROXY_MODE} "${ipt_j}")"
 				[ -n "${is_tproxy}" ] && $ipt_m -A PSW $(comment "本机") -p tcp -i lo $(REDIRECT $TCP_REDIR_PORT TPROXY)
 			}
 			[ -z "${is_tproxy}" ] && $ipt_n -A OUTPUT -p tcp -j PSW_OUTPUT


### PR DESCRIPTION
## Bug 1: TCP/UDP Default Proxy Mode = "No Proxy" is silently ignored

**Root cause — `app.sh`:**

```sh
TCP_PROXY_MODE=$(config_t_get global tcp_proxy_mode proxy)
[ "${TCP_PROXY_MODE}" != "disable" ] && TCP_PROXY_MODE="proxy"  # overwrites "direct" → "proxy"
```

The condition only guards against `"disable"`. When the user sets "TCP Default Proxy Mode = No Proxy" in the UI (`tcp_proxy_mode=direct`), it passes the check and gets silently overwritten to `"proxy"`.

**Root cause — `iptables.sh`:**

The catchall rule uses raw `${ipt_j}` (always REDIRECT) instead of `get_jump_ipt`, so even if `TCP_PROXY_MODE` were correct, the iptables catchall would still generate REDIRECT instead of RETURN for "direct" mode.

**Fix:**
- `app.sh`: add `&& [ "${TCP_PROXY_MODE}" != "direct" ]` guard (same for UDP)
- `iptables.sh`: use `get_jump_ipt ${TCP_PROXY_MODE}` for catchall in PSW and PSW_OUTPUT

---

## Bug 2: Saving Rule List wipes files for tabs not opened (data loss)

**Root cause — `rule_list.lua`:**

JS-LuCI lazy-loads tab content. If the user saves without opening every tab, those tabs' textarea fields are absent from the POST request. LuCI CBI sees `fvalue = nil` with `rmempty = true` and calls `remove()`, which calls `fs.writefile(file, "")` — silently wiping the file.

This affects all 9 file-backed options: `direct_host`, `direct_ip`, `proxy_host`, `proxy_ip`, `block_host`, `block_ip`, `lanlist_ipv4`, `lanlist_ipv6`, `hosts`.

**Repro:** Open Rule List → go to Proxy List tab only (do not open Direct List) → Save → `direct_ip` is now empty.

**Fix:** Make all `remove()` functions no-ops. An absent POST field means the tab was never loaded by the browser — it does not mean the user cleared the content.