### PR TITLE
fix(subscribe): correctly handle Clash 'network: http' for Xray (was xhttp → HTTP 400)

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/clash_subconverter.lua
+++ b/luci-app-passwall/root/usr/share/passwall/clash_subconverter.lua
@@ -99,7 +99,9 @@ local function build_common(node)
 	elseif net == "http" then
 		local opts = node["http-opts"]
 		if opts then
-			o.transport.host = get_first(opts.host)
+			-- Clash http-opts carries the camouflage Host under headers.Host
+			-- (a list), like ws-opts; opts.host is not standard for http.
+			o.transport.host = get_first(opts.host) or (opts.headers and get_first(opts.headers.Host))
 			o.transport.path = get_first(opts.path)
 		end
 

--- a/luci-app-passwall/root/usr/share/passwall/subscribe.lua
+++ b/luci-app-passwall/root/usr/share/passwall/subscribe.lua
@@ -597,7 +597,16 @@ local function processData(szType, content, add_mode, group, sub_cfg)
 		elseif result.type == "Xray" and info.net == "tcp" then
 			info.net = "raw"
 		end
-		if info.net == 'h2' or info.net == 'http' then
+		-- Clash 'network: http' = TCP + HTTP/1.1 header obfuscation (no TLS),
+		-- i.e. Xray raw transport with tcp header type "http" -- NOT xhttp
+		-- (splithttp). Normalize to 'raw' + guise 'http' so the tcp_guise
+		-- block below handles it; the server otherwise replies HTTP 400.
+		-- 'h2' still maps to xhttp (Xray dropped the standalone h2 transport).
+		if info.net == 'http' and result.type == "Xray" then
+			info.net = "raw"
+			info.type = "http"
+			result.transport = "raw"
+		elseif info.net == 'h2' or info.net == 'http' then
 			info.net = "http"
 			result.transport = (result.type == "Xray") and "xhttp" or "http"
 		else


### PR DESCRIPTION
## Problem

A vmess node from a **Clash** subscription with `network: http` (TCP + HTTP/1.1 header obfuscation, no TLS) never connects — every request through it returns **HTTP 400** (`transport/internet/splithttp: unexpected status 400` in the Xray log). Direct/CN traffic is unaffected, so it looks like a DNS or clock problem but is not.

Two bugs in the Clash-subscription path cause this:

1. **`clash_subconverter.lua`** reads the camouflage Host from `http-opts.host`, but Clash/mihomo carries it under `http-opts.headers.Host` (a list) — the same place as `ws-opts`. The Host is silently dropped.

2. **`subscribe.lua`** maps Clash `network: http` to the Xray **`xhttp`** (SplitHTTP) transport with `xhttp_mode=stream-one`. But Clash `network: http` is **HTTP/1.1 header obfuscation over raw TCP**, which in Xray is `raw` transport + tcp header type `http` — a different transport from `xhttp`, so the server rejects the SplitHTTP handshake with 400.

`network: http` and `h2` were handled in the same branch; only `http` is wrong — `h2` correctly maps to `xhttp` (Xray dropped the standalone h2 transport in favour of xhttp).

## Fix

- `clash_subconverter.lua`: read the Host from `http-opts.headers.Host` (mirrors the existing `ws-opts` handling), keeping `opts.host` as a fallback.
- `subscribe.lua`: for Xray, normalize `network: http` to `raw` + tcp guise `http`, so the existing `tcp_guise=http` path builds the correct outbound. `h2` → `xhttp` is unchanged.

## Verification

Reproduced and fixed on a live OpenWrt 24.10 / Xray 26.6.1 router against a real airport whose nodes use `vmess + network: http` (Host `www.baidu.com`, no TLS):

- **Before:** `splithttp: unexpected status 400`, node dead.
- **After:** `raw` + tcp header `http` with Host/path camouflage → connects, `curl` returns **HTTP 200/204**.

The converter now also emits the Host: a `network: http` node converts to `vmess://…` with `"net":"http","host":"www.baidu.com","path":"/"` (previously `"host":""`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
