### PR TITLE
luci: add server startup delay setting

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/server/index.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/server/index.lua
@@ -13,6 +13,11 @@ t.addremove = false
 e = t:option(Flag, "enable", translate("Enable"))
 e.rmempty = false
 
+e = t:option(Value, "start_delay", translate("Delay Start"), translate("Units:seconds"))
+e.default = "90"
+e.datatype = "range(0,600)"
+e.rmempty = false
+
 local cfgname = "user"
 t = m:section(TypedSection, cfgname, translate("Users Manager"))
 t.anonymous = true

--- a/luci-app-passwall/root/etc/config/passwall_server
+++ b/luci-app-passwall/root/etc/config/passwall_server
@@ -1,4 +1,4 @@
 
 config global 'global'
 	option enable '0'
-
+	option start_delay '90'

--- a/luci-app-passwall/root/etc/init.d/passwall_server
+++ b/luci-app-passwall/root/etc/init.d/passwall_server
@@ -3,7 +3,13 @@
 START=99
 
 boot_func() {
-	sleep 90
+	config_load passwall_server
+	config_get start_delay global start_delay 90
+	case "$start_delay" in
+		''|*[!0-9]*) start_delay=90 ;;
+		*) [ "$start_delay" -le 600 ] 2>/dev/null || start_delay=90 ;;
+	esac
+	[ "$start_delay" -gt 0 ] && sleep "$start_delay"
 	restart
 }
 


### PR DESCRIPTION
## Summary
- add a configurable boot delay to the PassWall Server global settings
- preserve the existing 90-second delay as the default and fallback
- accept values from 0 to 600 seconds, where 0 starts immediately
- keep manual start and restart operations immediate

## Testing
- `sh -n luci-app-passwall/root/etc/init.d/passwall_server`
- deployed on OpenWrt and verified the UCI value and generated LuCI option