### PR TITLE
luci: preserve empty Hy bandwidth settings

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
@@ -221,11 +221,9 @@ if #hysteria2_type > 0 then
 
 	o = s:option(Value, "hysteria_up_mbps", "Hy/Hy2 " .. translate("Max upload Mbps"))
 	o.datatype = "uinteger"
-	o.default = "100"
 
 	o = s:option(Value, "hysteria_down_mbps", "Hy/Hy2 " .. translate("Max download Mbps"))
 	o.datatype = "uinteger"
-	o.default = "100"
 end
 
 o = s:option(Flag, "boot_update", translate("Update Once on Boot"), translate("Updates the subscription the first time PassWall runs automatically after each system boot."))


### PR DESCRIPTION
Remove the CBI default values for subscription-level Hy/Hy2 bandwidth settings.

When these values are cleared, UCI correctly removes the options, but `o.default = "100"` repopulates the fields after the page reload. Removing the display defaults preserves empty configuration values.