### PR TITLE
fix: don't prefix literal /dev/null log_file with TMP_PATH

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -332,7 +332,7 @@ run_socks() {
 	[ -n "$config_file" ] && [ -z "$(echo ${config_file} | grep $TMP_PATH)" ] && config_file=$TMP_PATH/$config_file
 	[ -n "$http_port" ] || http_port=0
 	[ -n "$http_config_file" ] && [ -z "$(echo ${http_config_file} | grep $TMP_PATH)" ] && http_config_file=$TMP_PATH/$http_config_file
-	if [ -n "$log_file" ] && [ -z "$(echo ${log_file} | grep $TMP_PATH)" ]; then
+	if [ -n "$log_file" ] && [ "$log_file" != "/dev/null" ] && [ -z "$(echo ${log_file} | grep $TMP_PATH)" ]; then
 		log_file=$TMP_PATH/$log_file
 	else
 		log_file="/dev/null"
@@ -535,7 +535,7 @@ run_redir() {
 	eval_set_val "$@"
 	local tcp_node_socks_flag tcp_node_http_flag
 	[ -n "$config_file" ] && [ -z "$(echo ${config_file} | grep $TMP_PATH)" ] && config_file=${GLOBAL_ACL_PATH}/${config_file}
-	if [ -n "$log_file" ] && [ -z "$(echo ${log_file} | grep $TMP_PATH)" ]; then
+	if [ -n "$log_file" ] && [ "$log_file" != "/dev/null" ] && [ -z "$(echo ${log_file} | grep $TMP_PATH)" ]; then
 		log_file=${GLOBAL_ACL_PATH}/${log_file}
 	else
 		log_file="/dev/null"


### PR DESCRIPTION
run_socks() and run_redir() both prefix a non-empty log_file with
  TMP_PATH/GLOBAL_ACL_PATH. When a caller passes the literal string
  "/dev/null" (e.g. ACL logging disabled), it gets mangled into a path
  like "/tmp/etc/passwall//dev/null", which fails on first start because
  the tmpdir doesn't exist yet:

      app.sh: iptables.sh: line 487: can't create /tmp/etc/passwall//dev/null:
      nonexistent directory

  This adds a guard so the literal "/dev/null" keeps its special meaning,
  and the redirect in ln_run() works as intended.