### PR TITLE
luci: migrate legacy server sections

### DIFF
--- a/luci-app-passwall/root/etc/uci-defaults/luci-app-passwall_server
+++ b/luci-app-passwall/root/etc/uci-defaults/luci-app-passwall_server
@@ -24,6 +24,15 @@ else
 fi
 uci commit firewall
 
+# Migrate server sections from the old `user` section type. New user entries
+# also use `user`, so only sections with a server `type` option are renamed.
+for sid in $(uci -q show passwall_server | sed -n 's/^passwall_server\.\([^.=]*\)=user$/\1/p'); do
+	if [ -n "$(uci -q get "passwall_server.${sid}.type")" ]; then
+		uci -q set "passwall_server.${sid}=server"
+	fi
+done
+uci -q commit passwall_server
+
 rm -f /tmp/luci-indexcache /tmp/luci-indexcache.*
 rm -rf /tmp/luci-modulecache/
 killall -HUP rpcd 2>/dev/null


### PR DESCRIPTION
## Summary
- migrate legacy `passwall_server` sections from `user` to `server`
- identify legacy server entries by their `type` option
- preserve new user credential sections that also use the `user` section type
- run the migration from the dedicated server uci-defaults script

## Testing
- `sh -n luci-app-passwall/root/etc/uci-defaults/luci-app-passwall_server`
- `sh -n luci-app-passwall/root/etc/uci-defaults/luci-app-passwall`
- `git diff --check`