### PR TITLE
luci: migrate legacy HAProxy health check type

### DIFF
--- a/luci-app-passwall/root/etc/uci-defaults/luci-app-passwall
+++ b/luci-app-passwall/root/etc/uci-defaults/luci-app-passwall
@@ -37,6 +37,8 @@ chmod +x /usr/share/passwall/*.sh
 uci -q delete passwall.@global_xray[0].sniffing
 uci -q delete passwall.@global_xray[0].route_only
 
+[ "$(uci -q get passwall.@global_haproxy[0].health_check_type)" = "passwall_logic" ] && uci -q set passwall.@global_haproxy[0].health_check_type='script_logic'
+
 for sid in $(uci show passwall | grep "=socks" | awk -F '.' '{print $2}' | awk -F '=' '{print $1}'); do
 	if [ -z "$(echo ${sid} | grep '^socks_')" ]; then
 		new_id="socks_$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 5)"

--- a/luci-app-passwall/root/etc/uci-defaults/luci-app-passwall_server
+++ b/luci-app-passwall/root/etc/uci-defaults/luci-app-passwall_server
@@ -24,6 +24,15 @@ else
 fi
 uci commit firewall
 
+# Migrate server sections from the old `user` section type. New user entries
+# also use `user`, so only sections with a server `type` option are renamed.
+for sid in $(uci -q show passwall_server | sed -n 's/^passwall_server\.\([^.=]*\)=user$/\1/p'); do
+	if [ -n "$(uci -q get "passwall_server.${sid}.type")" ]; then
+		uci -q set "passwall_server.${sid}=server"
+	fi
+done
+uci -q commit passwall_server
+
 rm -f /tmp/luci-indexcache /tmp/luci-indexcache.*
 rm -rf /tmp/luci-modulecache/
 killall -HUP rpcd 2>/dev/null


### PR DESCRIPTION
## Summary

- migrate the legacy HAProxy health check value `passwall_logic` to `script_logic` during package upgrade
- preserve `tcp` and already migrated configurations unchanged

## Root cause

Commit `9c9251f6` renamed the persisted `health_check_type` enum but did not migrate existing UCI configuration. Upgraded installations therefore skipped the script-based node conversion and HAProxy forwarded SOCKS traffic directly to protocol endpoints such as Hysteria2/AnyTLS, resulting in EOF errors.

## Test

- `sh -n luci-app-passwall/root/etc/uci-defaults/luci-app-passwall`
- `git diff --check upstream/main...HEAD`