### PR TITLE
fix: add mwan3 exemption rule via iptables-nft instead of native nft

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -908,16 +908,22 @@ add_script_mwan3() {
 	}
 }
 
+MWAN3_RULE_ARGS="-m connmark --mark ${FWMARK}/0xffffffff -j RETURN"
+
 mwan3_stop() {
+	nft list chain ip mangle mwan3_hook >/dev/null 2>&1 || return 0
 	local handles=$(nft -a list chain ip mangle mwan3_hook 2>/dev/null | grep "${FWMARK}" | awk -F '# handle ' '{print$2}')
 	for handle in $handles; do
 		nft delete rule ip mangle mwan3_hook handle ${handle} 2>/dev/null
 	done
+	while iptables -w 5 -t mangle -D mwan3_hook ${MWAN3_RULE_ARGS} >/dev/null 2>&1; do :; done
 }
 
 mwan3_start() {
+	nft list chain ip mangle mwan3_hook >/dev/null 2>&1 || return 0
 	mwan3_stop
-	nft list chain ip mangle mwan3_hook >/dev/null 2>&1 && nft insert rule ip mangle mwan3_hook ct mark ${FWMARK} counter return >/dev/null 2>&1
+	iptables -w 5 -t mangle -I mwan3_hook 1 ${MWAN3_RULE_ARGS} >/dev/null 2>&1 || \
+		logger -t passwall "mwan3: failed to add ${FWMARK} exemption rule to mangle/mwan3_hook"
 }
 
 update_wan_sets() {


### PR DESCRIPTION
### 问题

`mwan3_start()` 目前用 `nft insert` 往 `mangle/mwan3_hook` 里插豁免规则。这条链是 mwan3 通过 iptables-nft 创建并持有的，链里一旦混入 nft 原生规则，iptables-nft 就无法把整条链翻译回去，任何 iptables 读取都会失败：

```
chain `mwan3_hook' in table `mangle' is incompatible, use 'nft' tool.
```

而 mwan3 的热插拔脚本 `/etc/hotplug.d/iface/15-mwan3` 正是用这个读取动作来判断自己是否已经初始化：

```sh
$IPT4 -S mwan3_hook &>/dev/null || {
	LOG warn "hotplug called on $INTERFACE before mwan3 has been set up"
	exit 0
}
```

PassWall 插入规则之后，这个判断永远不会再成功，于是每一个 ifup / ifdown / connected / disconnected 事件都会提前退出。后果有两个：

1. **开机后接口永远停在 disabled。** mwan3 初始化时 WAN 往往还没拿到 DHCP 地址，会先记为 disabled，等 ifup 事件再改回 online。而那个事件被上面的判断挡掉了，状态再也翻不回来。
2. **故障切换静默失效。** `mwan3_set_policies_iptables()` 也在同一个判断后面。线路掉线时状态文字会变，实际路由策略不会更新，流量继续往断线走。

### 复现

装 mwan3 并启用两个 WAN，启动 PassWall，然后：

```sh
iptables -t mangle -S mwan3_hook          # incompatible
mwan3 status                              # ipv4 policies 一栏报同样的错
logread | grep mwan3-hotplug              # before mwan3 has been set up
```

重启路由器后 LuCI 的 mwan3 状态页两个接口都显示"已禁用"，但 `uci show mwan3` 里 `enabled` 一直是 1。

### 改动

改用 iptables-nft 添加同一条规则，语义完全等价：nft 的 `ct mark` 就是 iptables 的 connmark 匹配。匹配模块和 RETURN 目标都必定可用，因为 mwan3 自身就依赖 `iptables` 和 `iptables-mod-conntrack-extra`。

`mwan3_stop()` 保留原来的 nft handle 清理，用于清除旧版本遗留的原生规则，升级即可自愈。**顺序很重要**：必须先清原生规则，因为只要还有一条在，链就是 incompatible，iptables 的删除必然失败。另外把 iptables 删除写成循环，重复规则不会累积；`mwan3_start()` 仍然先调 `mwan3_stop()`，所以反复调用是幂等的。

### 测试

环境为 Kwrt 25.12-SNAPSHOT，mwan3 2.12.0，两条 WAN。

- 链和策略查询恢复正常，豁免规则位于第 1 位
- 连续调用 `mwan3_start` 三次，链中始终只有一条规则
- 手动注入一条 nft 原生规则模拟旧版本残留，下一次 `mwan3_start` 能清掉并恢复可读
- 掐掉一条线的探测做真实故障切换，策略正确切到单线并在恢复后切回，日志出现 `Execute disconnected/connected event`
- 重启路由器验证开机路径，两个接口正常进入 online

### 备注

`luci-app-passwall2` 里有一份完全相同的代码，同样受影响。如果这个改法可以接受，我可以再提一个对应的 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
