### PR TITLE
luci: add opt-in local DNS passthrough for Xray shunts

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -411,6 +411,31 @@ o:depends({singbox_dns_mode = "tcp"})
 o:depends({singbox_dns_mode = "tls"})
 o:depends({singbox_dns_mode = "quic"})
 
+o = s:taboption("DNS", Flag, "local_dns_passthrough", translate("Local DNS passthrough"))
+o.default = "0"
+o.description = translate("Forward complete DNS replies through the same loopback TCP resolver for direct and remote DNS. Only for the global Xray shunt with Dnsmasq; requires Xray 26.4.25 or newer.") .. "<br />" ..
+	translate("Disable FakeDNS, Filter Proxy Host IPv6 and EDNS Client Subnet first. The local resolver controls client DNS filtering and caching. Do not point it back to PassWall or port 53.")
+o:depends({ node = "__always__" })
+o.validate = function(self, value, section)
+	if value ~= "1" then return value end
+	local function form(option)
+		local field = s.fields[option]
+		return field and field:formvalue(section)
+	end
+	local node = form("node")
+	if not node or m:get(node, "type") ~= "Xray" or m:get(node, "protocol") ~= "_shunt"
+		or form("dns_shunt") ~= "dnsmasq" or form("direct_dns_mode") ~= "tcp" or form("xray_dns_mode") ~= "tcp"
+		or api.compare_versions(api.get_app_version("xray"), "<", "26.4.25") then
+		return nil, translate("Local DNS passthrough requires a global Xray shunt, Dnsmasq, TCP DNS and Xray 26.4.25 or newer.")
+	end
+	if m:get(node, "fakedns") == "1" or m:get(node, "default_node") == "_blackhole"
+		or form("remote_fakedns") == "1" or form("filter_proxy_ipv6") == "1"
+		or (form("remote_dns_client_ip") or "") ~= "" then
+		return nil, translate("Local DNS passthrough cannot be combined with FakeDNS, a default blackhole, IPv6 filtering or ECS.")
+	end
+	return value
+end
+
 ---- DoH
 o = s:taboption("DNS", Value, "remote_dns_doh", translate("Remote DNS DoH"))
 o.description = translate("Format: URL[,IP] (optional IP to map the domain in the URL)")
@@ -761,6 +786,7 @@ for k, v in pairs(nodes_table) do
 			s.fields["_node_sel_shunt"]:depends({ node = v.id })
 			if m:get(v.id, "type") == "Xray" then
 				s.fields["xray_dns_mode"]:depends({ node = v.id })
+				s.fields["local_dns_passthrough"]:depends({ node = v.id, dns_shunt = "dnsmasq" })
 			else
 				s.fields["singbox_dns_mode"]:depends({ node = v.id })
 				s.fields["remote_rewrite_ttl"]:depends({ node = v.id })

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -117,6 +117,7 @@ if node_value then
 	current_node_id = node_value
 end
 current_node = current_node_id and m:get(current_node_id) or {}
+local shunt_default_node, shunt_default_row
 
 -- Shunt Start
 if (has_singbox or has_xray) and #nodes_table > 0 then
@@ -129,6 +130,12 @@ if (has_singbox or has_xray) and #nodes_table > 0 then
 				tab = "Shunt",
 				tab_desc = translate("Shunt Rule"),
 			})
+			for row, rule in pairs(s2.data or {}) do
+				if rule._node_option == "default_node" then
+					shunt_default_node, shunt_default_row = s2.fields._node, row
+					break
+				end
+			end
 		end
 	else
 		local tips = s:taboption("Main", DummyValue, "tips", "　")
@@ -428,7 +435,17 @@ o.validate = function(self, value, section)
 		or api.compare_versions(api.get_app_version("xray"), "<", "26.4.25") then
 		return nil, translate("Local DNS passthrough requires a global Xray shunt, Dnsmasq, TCP DNS and Xray 26.4.25 or newer.")
 	end
-	if m:get(node, "fakedns") == "1" or m:get(node, "default_node") == "_blackhole"
+	local default_node, fakedns = m:get(node, "default_node"), m:get(node, "fakedns")
+	local node_save_before = luci.http.formvalue("node_save_before")
+	-- The shunt Table is parsed after this section. Check the values that its
+	-- write callbacks will apply, not the old UCI values; respect skipped writes.
+	if (not node_save_before or node_save_before == node) and luci.http.formvalue("load_shunt") ~= "1" then
+		if shunt_default_node then
+			default_node = shunt_default_node:formvalue(shunt_default_row) or default_node
+		end
+		if s.fields.fakedns then fakedns = form("fakedns") end
+	end
+	if fakedns == "1" or default_node == "_blackhole"
 		or form("remote_fakedns") == "1" or form("filter_proxy_ipv6") == "1"
 		or (form("remote_dns_client_ip") or "") ~= "" then
 		return nil, translate("Local DNS passthrough cannot be combined with FakeDNS, a default blackhole, IPv6 filtering or ECS.")

--- a/luci-app-passwall/luasrc/passwall/util_sing-box.lua
+++ b/luci-app-passwall/luasrc/passwall/util_sing-box.lua
@@ -481,9 +481,9 @@ function gen_outbound(flag, node, tag, proxy_table)
 				obfs = node.hysteria_obfs,
 				auth = (node.hysteria_auth_type == "base64") and node.hysteria_auth_password or nil,
 				auth_str = (node.hysteria_auth_type == "string") and node.hysteria_auth_password or nil,
-				recv_window_conn = tonumber(node.hysteria_recv_window_conn),  --1.14 将变更为 stream_receive_window
-				recv_window = tonumber(node.hysteria_recv_window),  --1.14 将变更为 connection_receive_window
-				disable_mtu_discovery = (node.hysteria_disable_mtu_discovery == "1") and true or false,  --1.14 将变更为 disable_path_mtu_discovery
+				stream_receive_window = tonumber(node.hysteria_recv_window_conn),
+				connection_receive_window = tonumber(node.hysteria_recv_window),
+				disable_path_mtu_discovery = (node.hysteria_disable_mtu_discovery == "1") and true or false,
 				tls = tls
 			}
 		end
@@ -910,10 +910,10 @@ function gen_config_server(node)
 			down_mbps = tonumber(node.hysteria_down_mbps),
 			obfs = node.hysteria_obfs,
 			users = users,
-			recv_window_conn = node.hysteria_recv_window_conn and tonumber(node.hysteria_recv_window_conn) or nil, --1.14 to stream_receive_window
-			recv_window_client = node.hysteria_recv_window_client and tonumber(node.hysteria_recv_window_client) or nil, --1.14 to connection_receive_window
-			max_conn_client = node.hysteria_max_conn_client and tonumber(node.hysteria_max_conn_client) or nil,  --1.14 to max_concurrent_streams
-			disable_mtu_discovery = (node.hysteria_disable_mtu_discovery == "1") and true or false,  --1.14 to disable_path_mtu_discover
+			stream_receive_window = node.hysteria_recv_window_conn and tonumber(node.hysteria_recv_window_conn) or nil,
+			connection_receive_window = node.hysteria_recv_window_client and tonumber(node.hysteria_recv_window_client) or nil,
+			max_concurrent_streams = node.hysteria_max_conn_client and tonumber(node.hysteria_max_conn_client) or nil,
+			disable_path_mtu_discover = (node.hysteria_disable_mtu_discovery == "1") and true or false,
 			tls = tls
 		}
 	end

--- a/luci-app-passwall/luasrc/passwall/util_xray.lua
+++ b/luci-app-passwall/luasrc/passwall/util_xray.lua
@@ -901,6 +901,34 @@ function gen_config(var)
 	local use_proxy_list = var["use_proxy_list"]
 	local use_gfw_list = var["use_gfw_list"]
 	local chn_list = var["chn_list"]
+	local local_dns_passthrough = var["local_dns_passthrough"] == "1"
+	local local_dns_address, local_dns_port
+	if local_dns_passthrough then
+		local node = api.uci_get_c(node_id) or {}
+		assert(flag == "global" and node.type == "Xray" and node.protocol == "_shunt" and dns_listen_port,
+			"Local DNS passthrough requires the global Xray shunt DNS instance")
+		assert(not api.compare_versions(xray_version, "<", "26.4.25"),
+			"Local DNS passthrough requires Xray 26.4.25 or newer")
+		local function loopback(address)
+			address = (address or ""):gsub("^%[(.-)%]$", "%1")
+			if address == "0:0:0:0:0:0:0:1" then address = "::1" end
+			if address == "127.0.0.1" or address == "::1" then return address end
+		end
+		local_dns_address = loopback(direct_dns_tcp_server)
+		local_dns_port = tonumber(direct_dns_port) or 53
+		assert(local_dns_address and local_dns_address == loopback(remote_dns_tcp_server)
+			and not direct_dns_udp_server and not remote_dns_udp_server and not remote_dns_doh
+			and local_dns_port == (tonumber(remote_dns_tcp_port) or 53)
+			and local_dns_port >= 1 and local_dns_port <= 65535 and local_dns_port % 1 == 0,
+			"Local DNS passthrough requires the same loopback TCP server and port for direct and remote DNS")
+		assert(local_dns_port ~= 53 and local_dns_port ~= tonumber(dns_listen_port),
+			"Local DNS passthrough must not point back to the DNS frontend")
+		assert((not direct_dns_query_strategy or direct_dns_query_strategy == "" or direct_dns_query_strategy == "UseIP")
+			and remote_dns_query_strategy == "UseIP"
+			and (not remote_dns_client_ip or remote_dns_client_ip == "")
+			and not dns_socks_address and not dns_socks_port,
+			"Local DNS passthrough requires unfiltered DNS without ECS or a DNS SOCKS proxy")
+	end
 
 	local dns_domain_rules = {}
 	local dns = nil
@@ -1782,6 +1810,10 @@ function gen_config(var)
 
 		local dns_rule_position = 1
 		local remote_dns_outbound
+		if local_dns_passthrough then
+			assert(not fakedns and COMMON.default_outbound_tag and COMMON.default_outbound_tag ~= "blackhole",
+				"Local DNS passthrough is incompatible with FakeDNS or a default blackhole")
+		end
 		if dns_listen_port then
 			table.insert(inbounds, {
 				listen = "127.0.0.1",
@@ -1809,6 +1841,12 @@ function gen_config(var)
 					rules = (api.compare_versions(xray_version, ">", "26.4.17")) and {} or nil
 				}
 			}
+			if local_dns_passthrough then
+				-- Keep the whole reply (including CNAME and non-address records) at the local resolver.
+				remote_dns_outbound.settings.address = local_dns_address
+				remote_dns_outbound.settings.port = local_dns_port
+				remote_dns_outbound.streamSettings = { sockopt = { dialerProxy = "direct" } }
+			end
 
 			table.insert(routing.rules, 1, {
 				inboundTag = {
@@ -1873,7 +1911,7 @@ function gen_config(var)
 						})
 					else
 						table.insert(remote_dns_out_rules, {
-							action = "hijack",
+							action = local_dns_passthrough and "direct" or "hijack",
 							qType = "1,28",
 							domain = api.clone(value.domain)
 						})
@@ -1940,7 +1978,7 @@ function gen_config(var)
 		if remote_dns_outbound then
 			if remote_dns_outbound.settings.rules then
 				table.insert(remote_dns_out_rules, {
-					action = "hijack",
+					action = local_dns_passthrough and "direct" or "hijack",
 					qType = "1,28"
 				})
 				table.insert(remote_dns_out_rules, {

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -2189,3 +2189,18 @@ msgstr "配置支持的密码套件列表，以冒号 (:) 分隔。"
 
 msgid "Connection Reuse"
 msgstr "连接复用"
+
+msgid "Local DNS passthrough"
+msgstr "本地 DNS 透传"
+
+msgid "Forward complete DNS replies through the same loopback TCP resolver for direct and remote DNS. Only for the global Xray shunt with Dnsmasq; requires Xray 26.4.25 or newer."
+msgstr "将直连和远程 DNS 的完整应答交给同一个回环地址上的 TCP 解析器。仅适用于使用 Dnsmasq 的全局 Xray 分流节点，需要 Xray 26.4.25 或更新版本。"
+
+msgid "Disable FakeDNS, Filter Proxy Host IPv6 and EDNS Client Subnet first. The local resolver controls client DNS filtering and caching. Do not point it back to PassWall or port 53."
+msgstr "请先关闭 FakeDNS、过滤代理域名 IPv6 和 EDNS Client Subnet。客户端 DNS 的过滤和缓存由本地解析器负责；该解析器不能回指 PassWall 或 53 端口。"
+
+msgid "Local DNS passthrough requires a global Xray shunt, Dnsmasq, TCP DNS and Xray 26.4.25 or newer."
+msgstr "本地 DNS 透传需要全局 Xray 分流节点、Dnsmasq、TCP DNS，以及 Xray 26.4.25 或更新版本。"
+
+msgid "Local DNS passthrough cannot be combined with FakeDNS, a default blackhole, IPv6 filtering or ECS."
+msgstr "本地 DNS 透传不能与 FakeDNS、默认黑洞、IPv6 过滤或 ECS 同时使用。"

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -200,6 +200,7 @@ run_singbox() {
 
 run_xray() {
 	local flag type node redir_port tcp_proxy_way socks_address socks_port socks_username socks_password http_address http_port http_username http_password
+	local local_dns_passthrough
 	local dns_listen_port direct_dns_query_strategy direct_dns_port direct_dns_udp_server direct_dns_tcp_server remote_dns_protocol remote_dns_udp_server remote_dns_tcp_server remote_dns_doh remote_dns_client_ip remote_fakedns remote_dns_query_strategy dns_cache dns_socks_address dns_socks_port
 	local loglevel log_file config_file server_host server_port no_run use_proxy_list use_gfw_list chn_list
 	eval_set_val "$@"
@@ -278,6 +279,7 @@ run_xray() {
 
 	json_add_string "loglevel" "$loglevel"
 	[ -n "$no_run" ] && json_add_string "no_run" "1"
+	[ "$local_dns_passthrough" = "1" ] && json_add_string "local_dns_passthrough" "1"
 	local _json_arg="$(json_dump)"
 	lua $UTIL_XRAY gen_config "${_json_arg}" > $config_file
 	[ -n "$no_run" ] && return
@@ -753,6 +755,9 @@ start_global() {
 			}
 			NEXT_DNS_LISTEN_PORT=$(expr $NEXT_DNS_LISTEN_PORT + 1)
 		}
+		[ "$protocol" = "_shunt" ] && [ "$DNS_SHUNT" = "dnsmasq" ] &&
+			[ "$(config_n_get @global[0] local_dns_passthrough 0)" = "1" ] &&
+			_args="${_args} local_dns_passthrough=1"
 		_args="${_args} use_proxy_list=$USE_PROXY_LIST use_gfw_list=$USE_GFW_LIST chn_list=$CHN_LIST"
 		run_xray flag=$_flag node=$NODE redir_port=$REDIR_PORT tcp_proxy_way=$TCP_PROXY_WAY config_file=$config_file log_file=$log_file ${_args}
 	;;

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -200,7 +200,7 @@ run_singbox() {
 
 run_xray() {
 	local flag type node redir_port tcp_proxy_way socks_address socks_port socks_username socks_password http_address http_port http_username http_password
-	local local_dns_passthrough
+	local local_dns_passthrough=0
 	local dns_listen_port direct_dns_query_strategy direct_dns_port direct_dns_udp_server direct_dns_tcp_server remote_dns_protocol remote_dns_udp_server remote_dns_tcp_server remote_dns_doh remote_dns_client_ip remote_fakedns remote_dns_query_strategy dns_cache dns_socks_address dns_socks_port
 	local loglevel log_file config_file server_host server_port no_run use_proxy_list use_gfw_list chn_list
 	eval_set_val "$@"

--- a/tests/README-local-dns.md
+++ b/tests/README-local-dns.md
@@ -4,6 +4,7 @@ Run from the repository root with Lua 5.1:
 
 ```sh
 lua tests/test_xray_local_dns.lua
+python3 tests/test_xray_local_dns_bridge.py
 ```
 
 The test loads the real Xray `gen_config(var)` in a fresh environment for each
@@ -18,6 +19,11 @@ endpoint. The suite checks complete generated configurations, ordered DNS
 policy, unchanged node DNS, default-off compatibility and rejected conflicts.
 This is a configuration-generation test, not a Linux packet-path or Xray wire
 protocol integration test.
+
+The Python smoke test executes the real `run_xray` and `eval_set_val` shell
+functions with substituted UCI/JSON/Lua boundaries and `no_run=1`. It also
+executes the global Xray arm's opt-in selection statement over 18 combinations.
+It checks argument serialization and isolation, not full service orchestration.
 
 ## Opt-in behavior
 

--- a/tests/README-local-dns.md
+++ b/tests/README-local-dns.md
@@ -1,0 +1,52 @@
+# Local DNS passthrough regression
+
+Run from the repository root with Lua 5.1:
+
+```sh
+lua tests/test_xray_local_dns.lua
+```
+
+The test loads the real Xray `gen_config(var)` in a fresh environment for each
+case. Synthetic UCI records and the LuCI API boundary replace router services;
+JSON serialization returns the generated table for comparison. Shell writes,
+service calls and filesystem operations fail the test. No DNS queries, proxy
+credentials, OpenWrt image or root privileges are required.
+
+The initial passthrough assertion fails on the unpatched generator because the
+DNS outbound still targets a public resolver rather than the configured local
+endpoint. The suite checks complete generated configurations, ordered DNS
+policy, unchanged node DNS, default-off compatibility and rejected conflicts.
+This is a configuration-generation test, not a Linux packet-path or Xray wire
+protocol integration test.
+
+## Opt-in behavior
+
+The **Local DNS passthrough** option is for the global Xray shunt node with
+Dnsmasq. It is disabled by default and does not propagate to independent ACL,
+SOCKS or other-core instances. For example, both direct and remote DNS may be
+configured as TCP `127.0.0.1:5533`, with a separately managed local resolver
+already listening there. The implementation does not require MosDNS or fix the
+upstream port to a particular value.
+
+Requirements:
+
+- Xray 26.4.25 or newer, no FakeDNS, and no default blackhole.
+- Both DNS endpoints are the same TCP loopback address and port. Supported
+  loopback literals are `127.0.0.1` and `::1` (including bracketed/expanded IPv6).
+- Disable **Filter Proxy Host IPv6** and leave **EDNS Client Subnet** empty.
+  Both generated DNS query strategies must be `UseIP`; filtering and caching
+  for client queries are the local resolver's responsibility.
+- Do not use port 53, the Xray DNS listener port, or another DNS frontend that
+  forwards back to PassWall. The generator rejects the first two direct loops;
+  it cannot inspect an external resolver's configuration to detect indirect loops.
+
+An unsupported explicit configuration fails generation instead of silently
+falling back to the public DNS outbound. Disabling the option retains existing
+generation, including FakeDNS and address-family selection.
+
+When enabled, ordinary A/AAAA queries use `direct` instead of being reconstructed
+by Xray's built-in DNS. Other record types use the same configured TCP resolver.
+Existing `domain`, `qType`, rule order and explicit `return` policies are retained;
+this is not an instruction to bypass blocking rules. Xray's internal/node DNS,
+hosts and normal traffic routing are unchanged. The frontend dnsmasq still
+handles local names and domain-to-IP set population.

--- a/tests/README-local-dns.md
+++ b/tests/README-local-dns.md
@@ -4,6 +4,7 @@ Run from the repository root with Lua 5.1:
 
 ```sh
 lua tests/test_xray_local_dns.lua
+lua tests/test_xray_local_dns_form.lua
 python3 tests/test_xray_local_dns_bridge.py
 ```
 
@@ -24,6 +25,12 @@ The Python smoke test executes the real `run_xray` and `eval_set_val` shell
 functions with substituted UCI/JSON/Lua boundaries and `no_run=1`. It also
 executes the global Xray arm's opt-in selection statement over 18 combinations.
 It checks argument serialization and isolation, not full service orchestration.
+
+The form regression loads the complete CBI model and shunt-options include with
+separate stored UCI and submitted HTTP values. It invokes the actual Flag
+validation callback for simultaneous shunt-target/FakeDNS changes and skipped
+writes. It does not replace those two states with an already-updated UCI view,
+and does not claim to exercise a browser or the entire CBI save/apply lifecycle.
 
 ## Opt-in behavior
 

--- a/tests/test_xray_local_dns.lua
+++ b/tests/test_xray_local_dns.lua
@@ -1,0 +1,352 @@
+-- Run from the repository root with Lua 5.1:
+--   lua tests/test_xray_local_dns.lua
+-- Exercises the public gen_config(var) boundary with synthetic UCI records.
+-- No router, DNS server, LuCI installation, credentials or subprocesses needed.
+
+local source = "luci-app-passwall/luasrc/passwall/util_xray.lua"
+local function copy(value)
+	if type(value) ~= "table" then return value end
+	local result = {}
+	for key, item in pairs(value) do result[key] = copy(item) end
+	return result
+end
+
+local function equal(actual, expected, path)
+	path = path or "config"
+	assert(type(actual) == type(expected), path .. ": type differs")
+	if type(expected) ~= "table" then
+		assert(actual == expected, path .. ": expected " .. tostring(expected) .. ", got " .. tostring(actual))
+		return
+	end
+	for key, value in pairs(expected) do equal(actual[key], value, path .. "." .. tostring(key)) end
+	for key in pairs(actual) do assert(expected[key] ~= nil, path .. ": unexpected key " .. tostring(key)) end
+end
+
+local function fixture()
+	return {
+		version = "26.9.9",
+		sections = {
+			["@global[0]"] = {node = "shunt", chn_list = "direct"},
+			["@global_xray[0]"] = {},
+			["@global_rules[0]"] = {},
+			shunt = {
+				[".name"] = "shunt", [".type"] = "nodes", type = "Xray", protocol = "_shunt",
+				shunt_group = "test", default_node = "_direct", allow = "_direct", block = "_blackhole"
+			}
+		},
+		rules = {
+			{[".name"] = "allow", remarks = "Allow narrow match", group = "test", domain_list = "full:allowed.example.test"},
+			{[".name"] = "block", remarks = "Block broader match", group = "test", domain_list = "domain:example.test"}
+		},
+		var = {
+			flag = "global", node = "shunt", no_run = true, dns_listen_port = "15353",
+			direct_dns_tcp_server = "127.0.0.1", direct_dns_port = "5533", direct_dns_query_strategy = "UseIP",
+			remote_dns_tcp_server = "127.0.0.1", remote_dns_tcp_port = "5533", remote_dns_query_strategy = "UseIP"
+		}
+	}
+end
+
+local function generate(input)
+	local data = copy(input)
+	local function forbidden() error("unexpected external operation", 2) end
+	local api = {
+		c_config = "passwall", TMP_PATH = "/unused", TMP_IFACE_PATH = "/unused",
+		clone = copy,
+		trim = function(value) return (value or ""):match("^%s*(.-)%s*$") end,
+		get_app_version = function(name) assert(name == "xray"); return data.version end,
+		uci_get_c = function(section, option)
+			local value = data.sections[section]
+			return copy(option and value and value[option] or (not option and value or nil))
+		end,
+		uci_foreach_c = function(kind, callback)
+			assert(kind == "shunt_rules", "unexpected UCI enumeration: " .. tostring(kind))
+			for _, rule in ipairs(data.rules) do callback(copy(rule)) end
+		end,
+		is_ipv6 = function(value) return value and value:find(":", 1, true) ~= nil end,
+		get_ipv6_full = function(value) return value:match("^%[") and value or "[" .. value .. "]" end,
+		get_ipv6_only = function(value) return value:match("^%[(.-)%]$") or value end,
+		is_local_ip = function(value) return value:find("127.0.0.1", 1, true) or value:find("::1", 1, true) end,
+		vps_domain_exclude = function() return false end,
+		split = function(value, separator)
+			local items = {}
+			for item in value:gmatch("[^" .. separator .. "]+") do items[#items + 1] = item end
+			return items
+		end,
+		gen_random_char = function() return "fixture" end,
+		datatypes = {hostname = function(value) return value and value:find("%a") ~= nil end},
+		fs = setmetatable({}, {__index = function() return forbidden end}),
+		sys = {
+			call = forbidden,
+			exec = function(command)
+				assert(command:match("^uci show passwall | sed %-n "), "unexpected shell read")
+				return data.node_domains or ""
+			end
+		},
+		-- This boundary substitutes serialization only; generation remains real.
+		jsonc = {stringify = function(config) return copy(config) end}
+	}
+	api.cleanEmptyTables = function(value)
+		if type(value) ~= "table" then return nil end
+		for key, item in pairs(value) do
+			if type(item) == "table" then value[key] = api.cleanEmptyTables(item) end
+		end
+		return next(value) and value or nil
+	end
+	api.compare_versions = function(left, operator, right)
+		local a, b = {}, {}
+		for n in left:gmatch("%d+") do a[#a + 1] = tonumber(n) end
+		for n in right:gmatch("%d+") do b[#b + 1] = tonumber(n) end
+		local order = 0
+		for index = 1, math.max(#a, #b) do
+			if (a[index] or 0) ~= (b[index] or 0) then order = (a[index] or 0) < (b[index] or 0) and -1 or 1; break end
+		end
+		if operator == "<" then return order < 0 end
+		if operator == ">" then return order > 0 end
+		if operator == ">=" then return order >= 0 end
+		if operator == "<=" then return order <= 0 end
+		if operator == "==" or operator == "=" then return order == 0 end
+		error("unsupported comparison operator")
+	end
+	local environment = setmetatable({arg = {}, module = function() end}, {__index = _G})
+	environment._G = environment
+	environment.require = function(name)
+		assert(name == "luci.passwall.api", "unexpected module: " .. name)
+		return api
+	end
+	environment.io = setmetatable({}, {__index = function() return forbidden end})
+	environment.os = setmetatable({}, {__index = function() return forbidden end})
+	-- A fresh module environment also isolates the generator's DNS bookkeeping.
+	setfenv(assert(loadfile(source)), environment)()
+	return environment.gen_config(data.var)
+end
+
+local function outbound(config, tag)
+	local found
+	for _, value in ipairs(config.outbounds or {}) do
+		if value.tag == tag then assert(not found, "duplicate outbound " .. tag); found = value end
+	end
+	return assert(found, "missing outbound " .. tag)
+end
+
+local passed = 0
+local function test(name, run)
+	local ok, failure = pcall(run)
+	if not ok then io.stderr:write("FAIL " .. name .. ": " .. tostring(failure) .. "\n"); os.exit(1) end
+	passed = passed + 1
+	io.stdout:write("PASS " .. name .. "\n")
+end
+
+test("explicit zero preserves the entire default configuration", function()
+	local data = fixture()
+	local expected = generate(data)
+	data.var.local_dns_passthrough = "0"
+	equal(generate(data), expected)
+	equal(outbound(expected, "dns-out").settings.rules, {
+		{action = "hijack", qType = "1,28", domain = {"full:allowed.example.test"}},
+		{action = "return", rCode = 0, domain = {"domain:example.test"}},
+		{action = "hijack", qType = "1,28"},
+		{action = "direct"}
+	})
+end)
+
+test("explicit passthrough keeps the configured local DNS endpoint", function()
+	local data = fixture()
+	data.var.local_dns_passthrough = "1"
+	local dns = outbound(generate(data), "dns-out")
+	equal(dns.settings.address, "127.0.0.1", "dns-out address")
+	equal(dns.settings.port, 5533, "dns-out port")
+	equal(dns.settings.network, "tcp", "dns-out network")
+	equal(dns.streamSettings.sockopt.dialerProxy, "direct", "dns-out transport")
+end)
+
+test("passthrough changes only the approved client DNS fields", function()
+	local data = fixture()
+	local expected = generate(data)
+	local dns = outbound(expected, "dns-out")
+	dns.settings.address, dns.settings.port, dns.settings.network = "127.0.0.1", 5533, "tcp"
+	dns.streamSettings.sockopt.dialerProxy = "direct"
+	dns.settings.rules = {
+		{action = "direct", qType = "1,28", domain = {"full:allowed.example.test"}},
+		{action = "return", rCode = 0, domain = {"domain:example.test"}},
+		{action = "direct", qType = "1,28"},
+		{action = "direct"}
+	}
+	data.var.local_dns_passthrough = "1"
+	equal(generate(data), expected)
+end)
+
+-- Interpret the public rule format for these literal fixture domains. This is
+-- independent of the generator and makes overlapping allow/block behavior clear.
+local function action_for(rules, domain, qtype)
+	for _, rule in ipairs(rules) do
+		local type_matches = not rule.qType
+		for value in (rule.qType or ""):gmatch("[^,]+") do
+			if tonumber(value) == qtype then type_matches = true end
+		end
+		local domain_matches = not rule.domain
+		for _, matcher in ipairs(rule.domain or {}) do
+			local kind, value = matcher:match("^(%a+):(.*)$")
+			if kind == "full" and domain == value then domain_matches = true end
+			if kind == "domain" and (domain == value or domain:sub(-#value - 1) == "." .. value) then domain_matches = true end
+		end
+		if type_matches and domain_matches then return rule.action end
+	end
+	error("no matching DNS rule")
+end
+
+test("overlapping blackhole rules retain their record-type precedence", function()
+	local data = fixture()
+	data.var.local_dns_passthrough = "1"
+	local rules = outbound(generate(data), "dns-out").settings.rules
+	for _, qtype in ipairs({1, 28}) do
+		equal(action_for(rules, "allowed.example.test", qtype), "direct")
+		equal(action_for(rules, "blocked.example.test", qtype), "return")
+	end
+	for _, qtype in ipairs({5, 15, 16, 65}) do
+		-- Do not remove qType from the preceding allow rule: it would unblock these.
+		equal(action_for(rules, "allowed.example.test", qtype), "return")
+		equal(action_for(rules, "elsewhere.invalid", qtype), "direct")
+	end
+end)
+
+for _, port in ipairs({1053, 5335, 65535}) do
+	test("loopback port " .. port .. " is not hardcoded", function()
+		local data = fixture()
+		data.var.local_dns_passthrough = "1"
+		data.var.direct_dns_port, data.var.remote_dns_tcp_port = tostring(port), tostring(port)
+		equal(outbound(generate(data), "dns-out").settings.port, port)
+	end)
+end
+
+for _, addresses in ipairs({{"::1", "::1"}, {"[::1]", "::1"}, {"0:0:0:0:0:0:0:1", "::1"}}) do
+	test("IPv6 loopback normalization " .. addresses[1] .. " / " .. addresses[2], function()
+		local data = fixture()
+		data.var.local_dns_passthrough = "1"
+		data.var.direct_dns_tcp_server, data.var.remote_dns_tcp_server = addresses[1], addresses[2]
+		local settings = outbound(generate(data), "dns-out").settings
+		equal(settings.address, "::1")
+		equal(settings.port, 5533)
+	end)
+end
+
+test("the direct query strategy may use its existing UseIP default", function()
+	local data = fixture()
+	data.var.local_dns_passthrough, data.var.direct_dns_query_strategy = "1", nil
+	equal(outbound(generate(data), "dns-out").settings.address, "127.0.0.1")
+end)
+
+test("the oldest supported core accepts explicit passthrough", function()
+	local data = fixture()
+	data.version, data.var.local_dns_passthrough = "26.4.25", "1"
+	equal(outbound(generate(data), "dns-out").settings.address, "127.0.0.1")
+end)
+
+local function reject(name, change)
+	test("rejects " .. name, function()
+		local data = fixture()
+		data.var.local_dns_passthrough = "1"
+		change(data)
+		local ok, failure = pcall(generate, data)
+		assert(not ok, "unsupported passthrough configuration was silently accepted")
+		assert(tostring(failure):lower():find("passthrough", 1, true), "unrelated failure: " .. tostring(failure))
+	end)
+end
+
+reject("an ACL instance", function(data) data.var.flag = "acl_test" end)
+reject("a SOCKS instance", function(data) data.var.flag = "url_test_synthetic" end)
+reject("a missing global instance flag", function(data) data.var.flag = nil end)
+reject("a non-Xray shunt", function(data) data.sections.shunt.type = "sing-box" end)
+reject("a non-shunt node", function(data) data.sections.shunt.protocol = "socks" end)
+reject("a missing selected node", function(data) data.var.node = nil end)
+reject("a missing DNS listener", function(data) data.var.dns_listen_port = nil end)
+reject("a default blackhole", function(data) data.sections.shunt.default_node = "_blackhole" end)
+reject("different loopback addresses", function(data) data.var.remote_dns_tcp_server = "::1" end)
+reject("different endpoint ports", function(data) data.var.remote_dns_tcp_port = "5534" end)
+reject("direct UDP DNS", function(data) data.var.direct_dns_udp_server = "127.0.0.1" end)
+reject("remote UDP DNS", function(data) data.var.remote_dns_udp_server, data.var.remote_dns_udp_port = "127.0.0.1", "5533" end)
+reject("remote DoH DNS", function(data) data.var.remote_dns_doh = "https://resolver.invalid/dns-query" end)
+reject("a missing direct TCP endpoint", function(data) data.var.direct_dns_tcp_server = nil end)
+reject("a missing remote TCP endpoint", function(data) data.var.remote_dns_tcp_server = nil end)
+reject("the default remote UseIPv4 strategy", function(data) data.var.remote_dns_query_strategy = nil end)
+reject("an IPv4-only direct strategy", function(data) data.var.direct_dns_query_strategy = "UseIPv4" end)
+reject("an IPv6-only remote strategy", function(data) data.var.remote_dns_query_strategy = "UseIPv6" end)
+reject("configured ECS", function(data) data.var.remote_dns_client_ip = "192.0.2.123" end)
+reject("a DNS SOCKS proxy", function(data) data.var.dns_socks_address, data.var.dns_socks_port = "127.0.0.1", "1080" end)
+reject("an incomplete DNS SOCKS address", function(data) data.var.dns_socks_address = "127.0.0.1" end)
+reject("an incomplete DNS SOCKS port", function(data) data.var.dns_socks_port = "1080" end)
+reject("global FakeDNS", function(data) data.var.remote_dns_fake = "1" end)
+reject("per-rule FakeDNS", function(data) data.sections.shunt.fakedns, data.sections.shunt.allow_fakedns = "1", "1" end)
+reject("default-rule FakeDNS", function(data) data.sections.shunt.fakedns, data.sections.shunt.default_fakedns = "1", "1" end)
+reject("enabled shunt FakeDNS even without a selected fake rule", function(data) data.sections.shunt.fakedns = "1" end)
+
+for _, address in ipairs({"localhost", "192.168.1.1", "10.0.0.1", "8.8.8.8", "0.0.0.0", "::", "fd00::1"}) do
+	reject("non-loopback endpoint " .. address, function(data)
+		data.var.direct_dns_tcp_server, data.var.remote_dns_tcp_server = address, address
+	end)
+end
+for _, port in ipairs({"0", "-1", "65536", "5533.5", "invalid", "53", "15353"}) do
+	reject("unsafe endpoint port " .. port, function(data)
+		data.var.direct_dns_port, data.var.remote_dns_tcp_port = port, port
+	end)
+end
+for _, version in ipairs({"26.3.27", "26.4.17", "26.4.24"}) do
+	reject("unsupported Xray " .. version, function(data) data.version = version end)
+end
+
+test("disabled passthrough preserves older-core behavior", function()
+	local data = fixture()
+	data.version = "26.3.27"
+	local expected = generate(data)
+	equal(outbound(expected, "dns-out").settings.nonIPQuery, "reject")
+	equal(outbound(expected, "dns-out").settings.rules, nil)
+	data.var.local_dns_passthrough = "0"
+	equal(generate(data), expected)
+end)
+
+test("global UCI opt-in is not inherited without an instance argument", function()
+	local data = fixture()
+	data.var.flag = "acl_test"
+	local expected = generate(data)
+	data.sections["@global[0]"].local_dns_passthrough = "1"
+	equal(generate(data), expected)
+end)
+
+test("disabled passthrough preserves active FakeDNS", function()
+	local data = fixture()
+	data.var.remote_dns_fake = "1"
+	data.sections.shunt.fakedns, data.sections.shunt.default_fakedns = "1", "1"
+	local expected = generate(data)
+	assert(expected.fakedns and #expected.fakedns > 0)
+	data.var.local_dns_passthrough = "0"
+	equal(generate(data), expected)
+end)
+
+test("node DNS and internal resolver settings remain unchanged", function()
+	local data = fixture()
+	data.sections.shunt.default_node = "exit"
+	data.sections.exit = {
+		[".name"] = "exit", [".type"] = "nodes", type = "Xray", protocol = "socks",
+		address = "node.synthetic.test", port = "1080", transport = "tcp", stream_security = "none",
+		domain_resolver = "tcp", domain_resolver_dns = "192.0.2.53:5353"
+	}
+	local expected = generate(data)
+	equal(expected.dns.useSystemHosts, true)
+	local found = false
+	for _, server in ipairs(expected.dns.servers) do
+		if server.address == "tcp://192.0.2.53:5353" then
+			equal(server.domains, {"full:node.synthetic.test"}); found = true
+		end
+	end
+	assert(found, "fixture did not exercise custom node DNS")
+	data.var.local_dns_passthrough = "1"
+	local actual = generate(data)
+	equal(actual.dns, expected.dns)
+	equal(actual.routing, expected.routing)
+	equal(actual.inbounds, expected.inbounds)
+	for _, value in ipairs(expected.outbounds) do
+		if value.tag ~= "dns-out" then equal(outbound(actual, value.tag), value) end
+	end
+	equal(outbound(actual, "dns-out").streamSettings.sockopt.dialerProxy, "direct")
+end)
+
+io.stdout:write(string.format("%d tests passed\n", passed))

--- a/tests/test_xray_local_dns_bridge.py
+++ b/tests/test_xray_local_dns_bridge.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Offline smoke test of app.sh's real run_xray argument -> JSON bridge.
+
+Run with Python 3 from any directory. The extraction boundary is the complete
+top-level shell function, not a rewritten copy of its conditionals. Only UCI,
+JSON serialization, Lua and service boundaries are substituted; no service runs.
+"""
+
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "luci-app-passwall/root/usr/share/passwall/app.sh"
+UTILS = ROOT / "luci-app-passwall/root/usr/share/passwall/utils.sh"
+
+
+def function_source(path, name):
+    source = path.read_text()
+    match = re.search(r"^" + re.escape(name) + r"\(\) \{\n.*?^\}\n", source, re.M | re.S)
+    if not match:
+        raise AssertionError("Shell function extraction boundary changed: " + name)
+    return match.group()
+
+
+SHIM = r'''
+forbidden() { printf '%s\n' 'unexpected external operation' >&2; exit 97; }
+ln_run() { forbidden; }
+echolog() { forbidden; }
+config_n_get() {
+    case "$2" in
+        local_dns_passthrough) printf '%s' "$FAKE_UCI_OPT_IN" ;;
+        loglevel) printf warning ;;
+        *) forbidden ;;
+    esac
+}
+json_init() { JSON_VALUES=; }
+json_add_string() {
+    # All fixture values are simple ASCII scalars. Python parses the final JSON.
+    JSON_VALUES="${JSON_VALUES}${JSON_VALUES:+,}\"$1\":\"$2\""
+}
+json_dump() { printf '{%s}' "$JSON_VALUES"; }
+lua() {
+    [ "$#" = 3 ] && [ "$1" = synthetic-util ] && [ "$2" = gen_config ] || forbidden
+    printf '%s\n' "$3"
+}
+UTIL_XRAY=synthetic-util
+XRAY_BIN=forbidden
+'''
+
+
+def bridge(option=None, inherited=None, uci="1", flag="global"):
+    arguments = ["type=xray", "flag=" + flag, "node=synthetic-shunt", "no_run=1",
+                 "dns_listen_port=15353",
+                 "direct_dns_tcp_server=127.0.0.1#5533", "remote_dns_protocol=tcp",
+                 "remote_dns_tcp_server=127.0.0.1#5533", "remote_dns_query_strategy=UseIP"]
+    if option is not None:
+        arguments.append("local_dns_passthrough=" + option)
+    program = SHIM + function_source(UTILS, "eval_set_val") + function_source(APP, "run_xray")
+    environment = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "FAKE_UCI_OPT_IN": uci}
+    if inherited is not None:
+        environment["local_dns_passthrough"] = inherited
+    with tempfile.TemporaryDirectory(prefix="xray-bridge-") as temporary:
+        output = Path(temporary) / "config.json"
+        arguments.append("config_file=" + str(output))
+        program += "\nrun_xray " + " ".join(map(shlex.quote, arguments)) + "\n"
+        result = subprocess.run(["/bin/sh", "-c", program], env=environment,
+                                capture_output=True, text=True, timeout=10)
+        if result.returncode or result.stderr:
+            raise AssertionError("Shell bridge failed: " + result.stderr.strip())
+        return json.loads(output.read_text())
+
+
+def global_selection(protocol, dns_shunt, opt_in):
+    # Deliberately smaller seam: execute the actual opt-in statement from the
+    # global Xray arm, without mocking the complete service orchestration stack.
+    caller = function_source(APP, "start_global")
+    branch = caller.split("\n\txray)\n", 1)[1].split("\n\t;;", 1)[0]
+    match = re.search(r'^\t\t\[ "\$protocol"[^\n]*&& \[ "\$DNS_SHUNT".*?\n(?=\t\t_args=)',
+                      branch, re.M | re.S)
+    if not match:
+        raise AssertionError("Global Xray selection extraction boundary changed")
+    program = SHIM + "\n_args=\n" + match.group() + '\nprintf "%s" "$_args"\n'
+    environment = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                   "protocol": protocol, "DNS_SHUNT": dns_shunt, "FAKE_UCI_OPT_IN": opt_in}
+    result = subprocess.run(["/bin/sh", "-c", program], env=environment,
+                            capture_output=True, text=True, timeout=10)
+    if result.returncode or result.stderr:
+        raise AssertionError("Global selector failed: " + result.stderr.strip())
+    return result.stdout.split()
+
+
+class XrayBridgeTests(unittest.TestCase):
+    def test_explicit_opt_in_reaches_gen_config(self):
+        result = bridge(option="1", uci="0")
+        self.assertEqual(result["local_dns_passthrough"], "1")
+        self.assertEqual(result["direct_dns_tcp_server"], "127.0.0.1")
+        self.assertEqual(result["remote_dns_tcp_server"], "127.0.0.1")
+        self.assertEqual(result["direct_dns_port"], "5533")
+        self.assertEqual(result["remote_dns_tcp_port"], "5533")
+        self.assertEqual(result["no_run"], "1")
+
+    def test_missing_argument_does_not_read_global_uci(self):
+        for flag in ("global", "acl_synthetic", "url_test_synthetic"):
+            with self.subTest(flag=flag):
+                self.assertNotIn("local_dns_passthrough", bridge(flag=flag))
+
+    def test_missing_argument_does_not_inherit_environment(self):
+        for flag in ("global", "acl_synthetic", "url_test_synthetic"):
+            with self.subTest(flag=flag):
+                self.assertNotIn("local_dns_passthrough", bridge(inherited="1", flag=flag))
+
+    def test_explicit_zero_is_not_serialized(self):
+        self.assertNotIn("local_dns_passthrough", bridge(option="0", inherited="1"))
+
+    def test_global_caller_requires_shunt_dnsmasq_and_explicit_opt_in(self):
+        for protocol in ("_shunt", "socks", "_balancing"):
+            for dns_shunt in ("dnsmasq", "chinadns-ng", "smartdns"):
+                for opt_in in ("0", "1"):
+                    with self.subTest(protocol=protocol, dns_shunt=dns_shunt, opt_in=opt_in):
+                        expected = ["local_dns_passthrough=1"] if (
+                            protocol == "_shunt" and dns_shunt == "dnsmasq" and opt_in == "1") else []
+                        self.assertEqual(global_selection(protocol, dns_shunt, opt_in), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xray_local_dns_form.lua
+++ b/tests/test_xray_local_dns_form.lua
@@ -1,0 +1,193 @@
+-- Run from the repository root with Lua 5.1:
+--   lua tests/test_xray_local_dns_form.lua
+-- Loads the complete global CBI model and its real shunt-options include.
+-- Exercises the real passthrough validate callback, not browser or CBI parsing.
+-- Stored UCI values remain separate from the submitted HTTP form throughout.
+
+local root = "luci-app-passwall/luasrc/model/cbi/passwall/client/"
+local global_section = "@global[0]"
+local function cbid(section, option)
+	return "cbid.passwall." .. section .. "." .. option
+end
+
+local function fixture(old_default, new_default, old_fake, new_fake, controls)
+	local function forbidden() error("unexpected external operation or UCI write", 2) end
+	local stored = {
+		[global_section] = {node = "shunt"},
+		shunt = {
+			[".name"] = "shunt", type = "Xray", protocol = "_shunt",
+			default_node = old_default, fakedns = old_fake
+		}
+	}
+	local post = {node_save_before = "shunt"}
+	for option, value in pairs({
+		node = "shunt", dns_shunt = "dnsmasq", direct_dns_mode = "tcp", xray_dns_mode = "tcp",
+		fakedns = new_fake, direct_dns = "127.0.0.1:5533", remote_dns = "127.0.0.1:5533"
+	}) do post[cbid(global_section, option)] = value end
+	for key, value in pairs(controls or {}) do post[key] = value end
+	local node_list = {
+		normal_list = {{id = "exit", remark = "Synthetic exit"}},
+		shunt_list = {{id = "shunt", remark = "Synthetic shunt"}}
+	}
+	local api = {
+		c_config = "passwall", datatypes = {},
+		fs = {access = function() return false end},
+		i18n = {translate = function(value) return value end},
+		jsonc = {stringify = function() return "[]" end},
+		set_default_cbi = function() end,
+		finded_com = function(name) return name == "xray" end,
+		is_finded = function() return false end,
+		get_valid_nodes = function() return {
+			{id = "shunt", remark = "Synthetic shunt", type = "Xray", protocol = "_shunt"},
+			{id = "exit", remark = "Synthetic exit", node_type = "normal", type = "Xray", protocol = "socks"}
+		} end,
+		get_node_list = function() return node_list end,
+		get_app_version = function() return "26.9.9" end,
+		compare_versions = function(left, operator, right)
+			assert(left == "26.9.9" and operator == "<" and right == "26.4.25")
+			return false
+		end,
+		url = function() return "/unused" end,
+		return_map = function(map) return map end
+	}
+	local map = {config = "passwall", children = {}, api = api, set = forbidden, del = forbidden}
+	function map:get(section, option)
+		local values = stored[section]
+		return option and values and values[option] or (not option and values or nil)
+	end
+	function map:formvalue(key) return post[key] end
+	function map:foreach(kind, callback)
+		if kind == "shunt_rules" then
+			callback({[".name"] = "allow", remarks = "Synthetic allow"})
+		else
+			assert(kind == "socks", "unexpected UCI enumeration: " .. tostring(kind))
+		end
+	end
+	function map:template_path(path) return "passwall" .. path end
+	function map:appendTemplate() end
+	local classes = {}
+	for _, name in ipairs({"NamedSection", "TypedSection", "Table", "Flag", "ListValue", "Value", "DummyValue", "HideValue", "DynamicList"}) do
+		classes[name] = {}
+	end
+	function map:section(class, section, sectiontype)
+		local result = {map = self, config = self.config, fields = {}, children = {}, tabs = {}, tab_names = {}}
+		result.section = class ~= classes.Table and section or nil
+		result.data = class == classes.Table and section or nil
+		result.sectiontype = sectiontype
+		function result:tab(name, title)
+			self.tab_names[#self.tab_names + 1] = name
+			self.tabs[name] = {title = title, childs = {}}
+		end
+		function result:option(field_class, option)
+			local field = {section = self, map = map, config = self.config, option = option, deps = {}, keylist = {}, vallist = {}}
+			if field_class == classes.Flag then field.enabled, field.disabled = "1", "0" end
+			function field:value(key, label)
+				self.keylist[#self.keylist + 1] = key
+				self.vallist[#self.vallist + 1] = label or key
+			end
+			function field:depends(dependency, value)
+				self.deps[#self.deps + 1] = type(dependency) == "table" and dependency or {[dependency] = value}
+			end
+			function field:formvalue(row) return post[cbid(row, self.option)] end
+			self.fields[option] = field
+			self.children[#self.children + 1] = field
+			return field
+		end
+		function result:taboption(tab, ...) return self:option(...) end
+		self.children[#self.children + 1] = result
+		return result
+	end
+	local environment = setmetatable({
+		Map = function() return map end,
+		translate = function(value) return value end,
+		translatef = string.format,
+		luci = {http = {formvalue = function(key) return post[key] end}},
+		io = {popen = function(command) assert(command == "lsmod"); return nil end},
+		os = setmetatable({}, {__index = function() return forbidden end}),
+		require = function(name) assert(name == "luci.passwall.api"); return api end,
+		loadfile = function(path)
+			assert(path == "/usr/lib/lua/luci/model/cbi/passwall/client/include/shunt_options.lua")
+			return loadfile(root .. "include/shunt_options.lua")
+		end
+	}, {__index = _G})
+	for name, class in pairs(classes) do environment[name] = class end
+	setfenv(assert(loadfile(root .. "global.lua")), environment)()
+	local global, default_field, default_row
+	for _, section in ipairs(map.children) do
+		if section.section == global_section then global = section end
+		for row, values in pairs(section.data or {}) do
+			if values._node_option == "default_node" then default_field, default_row = section.fields._node, row end
+		end
+	end
+	assert(global and default_field and default_row, "model did not create the expected global and shunt fields")
+	post[cbid(default_row, default_field.option)] = new_default
+	local option = assert(global.fields.local_dns_passthrough)
+	return {
+		validate = function(value)
+			local result, message = option:validate(value, global_section)
+			assert(map:get("shunt", "default_node") == old_default, "validation overwrote stored default_node")
+			assert(map:get("shunt", "fakedns") == old_fake, "validation overwrote stored fakedns")
+			return result, message
+		end,
+		forbid_reads = function()
+			map.get, map.formvalue, api.get_app_version = forbidden, forbidden, forbidden
+			for _, section in ipairs(map.children) do
+				for _, field in pairs(section.fields) do field.formvalue = forbidden end
+			end
+		end,
+		option = option
+	}
+end
+
+local passed, failed = 0, 0
+local function test(name, run)
+	local ok, failure = pcall(run)
+	if ok then
+		passed = passed + 1
+		io.stdout:write("PASS " .. name .. "\n")
+	else
+		failed = failed + 1
+		io.stderr:write("FAIL " .. name .. ": " .. tostring(failure) .. "\n")
+	end
+end
+local function rejected(form)
+	local value, message = form.validate("1")
+	assert(value == nil, "incompatible submitted shunt settings were accepted")
+	assert(message and message:find("passthrough", 1, true), "missing passthrough validation error")
+end
+local function allowed(form)
+	local value, message = form.validate("1")
+	assert(value == "1", "valid submitted shunt settings were rejected: " .. tostring(message))
+end
+
+test("same-submit default Direct to Blackhole is rejected", function()
+	rejected(fixture("_direct", "_blackhole", "0", nil))
+end)
+test("same-submit default Blackhole to Direct is allowed", function()
+	allowed(fixture("_blackhole", "_direct", "0", nil))
+end)
+test("same-submit disabling shunt FakeDNS is allowed", function()
+	allowed(fixture("_direct", "_direct", "1", nil))
+end)
+test("same-submit enabling shunt FakeDNS is rejected", function()
+	rejected(fixture("_direct", "_direct", "0", "1"))
+end)
+for _, skipped in ipairs({
+	{name = "loading shunt options", controls = {load_shunt = "1"}},
+	{name = "switching the selected node", controls = {node_save_before = "previous"}}
+}) do
+	test(skipped.name .. " ignores unwritten incompatible form settings", function()
+		allowed(fixture("_direct", "_blackhole", "0", "1", skipped.controls))
+	end)
+	test(skipped.name .. " retains incompatible stored settings", function()
+		rejected(fixture("_blackhole", "_direct", "1", nil, skipped.controls))
+	end)
+end
+test("disabling passthrough skips incompatible-field validation", function()
+	local form = fixture("_blackhole", "_blackhole", "1", "1")
+	form.forbid_reads()
+	assert(form.option:validate("0", global_section) == "0")
+end)
+
+io.stdout:write(string.format("%d passed, %d failed\n", passed, failed))
+if failed > 0 then os.exit(1) end


### PR DESCRIPTION
## Problem

With a global Xray shunt and Dnsmasq, setting direct and remote DNS to the same
local TCP resolver does not currently give that resolver ownership of complete
client DNS replies:

- A/AAAA queries are `hijack`ed into Xray's internal DNS and reconstructed.
- Other query types fall through to a separate hard-coded public TCP/53 target.

This can produce different CNAME/record sets and different behavior for TXT,
SVCB/HTTPS and other types when comparing the frontend with the configured local
resolver. Xray's [DNS outbound documentation](https://xtls.github.io/config/outbounds/dns.html)
distinguishes `hijack` (A/AAAA only) from `direct` (forwarding to the DNS outbound
target).

## Change

Add a **default-off Local DNS passthrough option**, limited to the global Xray
shunt instance with Dnsmasq. It is passed explicitly through `run_xray`; ACL,
SOCKS and other-core instances do not inherit the global setting.

In this mode:

- Both direct and remote DNS must be the same loopback TCP endpoint. No MosDNS
  dependency, fixed resolver port or router-specific configuration is introduced.
- The DNS outbound uses that endpoint with `dialerProxy=direct`.
- Ordinary `hijack` rules become `direct` in place. Domain/type matchers, order
  and explicit `return` policies are preserved, including overlapping rules.
- Xray's internal/node DNS configuration, hosts and normal traffic routing stay
  unchanged. Dnsmasq remains responsible for local names and IP-set population.

The mode rejects unsupported explicit configurations rather than silently
changing their semantics: FakeDNS, a default blackhole, address-family filtering,
nonempty ECS, a DNS SOCKS proxy, mismatched/non-loopback endpoints, port 53 or the
Xray DNS listener as upstream, and Xray older than 26.4.25. Client DNS filtering
and caching are delegated to the local resolver. An indirect forwarding loop in
that external resolver remains an operator configuration responsibility.

Keeping this opt-in is intentional: automatically activating it whenever two
endpoints match would alter existing FakeDNS/IPv6 policies. Changing only the
hard-coded fallback would not address A/AAAA answer reconstruction.

## Tests

```sh
lua tests/test_xray_local_dns.lua
lua tests/test_xray_local_dns_form.lua
python3 tests/test_xray_local_dns_bridge.py
luac -p luci-app-passwall/luasrc/passwall/util_xray.lua
luac -p luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
sh -n luci-app-passwall/root/usr/share/passwall/app.sh
git diff --check
```

The Lua 5.1 regression calls the actual `gen_config(var)` with synthetic UCI/API
boundaries and forbids external operations. On the unpatched baseline the first
passthrough assertion fails with `expected 127.0.0.1, got 8.8.8.8`; the patched
generator passes 59 cases, including full-config comparisons, overlapping block
rules, IPv6, multiple ports, rejected conflicts and preserved node DNS.

The shell bridge passes 5 test methods / 26 synthetic shell scenarios. The form
callback regression passes 9 cases, with stored UCI kept separate from submitted
HTTP values. In particular, enabling passthrough while changing the default
shunt target or FakeDNS is validated against the values that will actually be
written, respecting node-switch and form-loading cases that skip those writes.

These are offline configuration/bridge tests, not a newly built OpenWrt package
or a new live-router deployment of this exact upstream patch. An earlier
router-specific implementation of the same DNS-out forwarding correction was
validated over UDP/TCP and multiple DNS record types; that private implementation
and its configuration are not part of this PR.

No package version bump, new package dependency, firewall-backend change or
automatic maintenance hook is included.
